### PR TITLE
fix: use AND operator in Manticore Content match to prevent OR-token degradation

### DIFF
--- a/src/HappyNotes.Services/SearchService.cs
+++ b/src/HappyNotes.Services/SearchService.cs
@@ -208,9 +208,18 @@ public class SearchService : ISearchService
                                         }
                                     }
                                 },
-                                new Dictionary<string, object> // Match in tags
+                                new Dictionary<string, object> // AND match in tags: all tokens must appear
                                 {
-                                    { "match", new Dictionary<string, string> { { "Tags", query } } }
+                                    { "match", new Dictionary<string, object>
+                                        {
+                                            { "Tags", new Dictionary<string, object>
+                                                {
+                                                    { "query", query },
+                                                    { "operator", "and" }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/src/HappyNotes.Services/SearchService.cs
+++ b/src/HappyNotes.Services/SearchService.cs
@@ -195,9 +195,18 @@ public class SearchService : ISearchService
                                         }
                                     }
                                 },
-                                new Dictionary<string, object> // Regular match as fallback
+                                new Dictionary<string, object> // AND match: all tokens must appear
                                 {
-                                    { "match", new Dictionary<string, string> { { "Content", query } } }
+                                    { "match", new Dictionary<string, object>
+                                        {
+                                            { "Content", new Dictionary<string, object>
+                                                {
+                                                    { "query", query },
+                                                    { "operator", "and" }
+                                                }
+                                            }
+                                        }
+                                    }
                                 },
                                 new Dictionary<string, object> // Match in tags
                                 {

--- a/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
@@ -270,9 +270,9 @@ public class SearchServiceTests
     }
 
     [Test]
-    public async Task GetNoteIdsByKeywordAsync_MultiTokenQuery_SendsAndOperatorInMatchClause()
+    public async Task GetNoteIdsByKeywordAsync_MultiTokenQuery_SendsAndOperatorInMatchClauses()
     {
-        // Regression test for phrase-matching fix: the Content "match" fallback must use
+        // Regression test for phrase-matching fix: both Content and Tags "match" clauses must use
         // operator:"and" so that multi-token CJK queries (e.g. "小菜园 浇水") require ALL
         // tokens to appear rather than any one of them.
         HttpRequestMessage? captured = null;
@@ -293,13 +293,14 @@ public class SearchServiceTests
         var body = await captured!.Content!.ReadAsStringAsync();
         using var doc = JsonDocument.Parse(body);
 
-        // Navigate into query.bool.must[0].bool.should to find the match clause
+        // Walk all must clauses looking for the bool/should block (position may change as code evolves)
         var must = doc.RootElement
             .GetProperty("query")
             .GetProperty("bool")
             .GetProperty("must");
 
-        string? foundOperator = null;
+        string? contentOperator = null;
+        string? tagsOperator = null;
         foreach (var mustClause in must.EnumerateArray())
         {
             if (!mustClause.TryGetProperty("bool", out var boolClause)) continue;
@@ -307,16 +308,19 @@ public class SearchServiceTests
             foreach (var shouldClause in should.EnumerateArray())
             {
                 if (!shouldClause.TryGetProperty("match", out var match)) continue;
-                if (!match.TryGetProperty("Content", out var contentClause)) continue;
-                if (contentClause.TryGetProperty("operator", out var op))
-                {
-                    foundOperator = op.GetString();
-                }
+                if (match.TryGetProperty("Content", out var contentClause) &&
+                    contentClause.TryGetProperty("operator", out var op))
+                    contentOperator = op.GetString();
+                if (match.TryGetProperty("Tags", out var tagsClause) &&
+                    tagsClause.TryGetProperty("operator", out var tagsOp))
+                    tagsOperator = tagsOp.GetString();
             }
         }
 
-        Assert.That(foundOperator, Is.EqualTo("and"),
+        Assert.That(contentOperator, Is.EqualTo("and"),
             "Content match clause must use operator:\"and\" to prevent OR-token relevance degradation");
+        Assert.That(tagsOperator, Is.EqualTo("and"),
+            "Tags match clause must also use operator:\"and\" for consistency with the Content fix");
     }
 
     [Test]

--- a/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using HappyNotes.Common.Enums;
 using HappyNotes.Entities;
 using HappyNotes.Services.interfaces;
@@ -266,6 +267,56 @@ public class SearchServiceTests
                 req.Method == HttpMethod.Post &&
                 req.RequestUri.ToString().Contains("json/update")),
             ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GetNoteIdsByKeywordAsync_MultiTokenQuery_SendsAndOperatorInMatchClause()
+    {
+        // Regression test for phrase-matching fix: the Content "match" fallback must use
+        // operator:"and" so that multi-token CJK queries (e.g. "小菜园 浇水") require ALL
+        // tokens to appear rather than any one of them.
+        HttpRequestMessage? captured = null;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"took\":0,\"timed_out\":false,\"hits\":{\"total\":0,\"hits\":[]}}")
+            });
+
+        await _searchService.GetNoteIdsByKeywordAsync(1, "小菜园 浇水", 1, 10, NoteFilterType.Normal);
+
+        Assert.IsNotNull(captured);
+        var body = await captured!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+
+        // Navigate into query.bool.must[0].bool.should to find the match clause
+        var must = doc.RootElement
+            .GetProperty("query")
+            .GetProperty("bool")
+            .GetProperty("must");
+
+        string? foundOperator = null;
+        foreach (var mustClause in must.EnumerateArray())
+        {
+            if (!mustClause.TryGetProperty("bool", out var boolClause)) continue;
+            if (!boolClause.TryGetProperty("should", out var should)) continue;
+            foreach (var shouldClause in should.EnumerateArray())
+            {
+                if (!shouldClause.TryGetProperty("match", out var match)) continue;
+                if (!match.TryGetProperty("Content", out var contentClause)) continue;
+                if (contentClause.TryGetProperty("operator", out var op))
+                {
+                    foundOperator = op.GetString();
+                }
+            }
+        }
+
+        Assert.That(foundOperator, Is.EqualTo("and"),
+            "Content match clause must use operator:\"and\" to prevent OR-token relevance degradation");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- The Content `match` fallback in `SearchService._BuildNoteSearchQuery()` previously used Manticore's default OR semantics, causing multi-token CJK queries to return notes that contain any single token rather than all tokens
- Adds `"operator": "and"` to the Content match clause — all tokens must be present
- The boosted `match_phrase` clause is unchanged; notes where tokens appear contiguously still score higher

## Test plan
- [x] `dotnet test` — 9 tests pass (1 new regression test)
- [x] New test: captures request body and asserts `operator:"and"` is present in the Content match clause

Fixes shukebeta/HappyNotes#34

🤖 Generated with [Claude Code](https://claude.com/claude-code)