### PR TITLE
fix: suppress NU1903 audit warnings for AutoMapper and SQLitePCLRaw

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <ItemGroup>
+    <!-- AutoMapper 12.0.1 / GHSA-rvv3-g6hj-g44x (CVE-2026-32933)
+         DoS via uncontrolled recursion when mapping deeply-nested self-referential graphs.
+         Non-exploitable here: entity graph terminates at Note.User→User; User has no
+         back-navigation to Note. No untrusted self-referential input reaches IMapper.Map.
+         Free patched line does not exist — AutoMapper ≥ 15.x requires a paid license.
+         Re-evaluate if self-referential DTOs or entities are introduced. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+
+    <!-- SQLitePCLRaw.lib.e_sqlite3 2.1.11 / GHSA-2m69-gcr7-jv3q (CVE-2025-6965)
+         Memory corruption in bundled SQLite < 3.50.2.
+         Non-exploitable here: test-only package (no production reference); localhost
+         test execution with trusted data only. Microsoft.Data.Sqlite 10.0.9 nuspec
+         hard-pins SQLitePCLRaw.core = 2.1.11, blocking any 3.x upgrade path.
+         Re-evaluate when Microsoft.Data.Sqlite moves to SQLitePCLRaw 3.x. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Creates `Directory.Build.props` at solution root with two `<NuGetAuditSuppress>` entries.
- AutoMapper (GHSA-rvv3-g6hj-g44x): non-exploitable DoS — entity graph terminates at `Note.User→User`; no free patched release exists (15.x+ is paid).
- SQLitePCLRaw.lib.e_sqlite3 (GHSA-2m69-gcr7-jv3q): test-only, non-exploitable — `Microsoft.Data.Sqlite 10.0.9` nuspec hard-pins `SQLitePCLRaw.core = 2.1.11`, blocking any 3.x upgrade path.
- Each suppression entry carries inline justification and a re-evaluation trigger.

## Test plan

- [x] `dotnet build` — zero `NU1903` warnings
- [x] `dotnet test --filter "TestCategory!=Integration"` — 167 passed, 0 failed

**Note:** `dotnet list package --vulnerable` still lists these packages — that command is an independent audit tool unaffected by `<NuGetAuditSuppress>`. The build-time warning suppression is the correct mechanism for silencing CI noise.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)