### PR TITLE
fix: route Manticore index purge through per-user queue task on PurgeDeleted

### DIFF
--- a/src/HappyNotes.Services/ManticoreSyncNoteService.cs
+++ b/src/HappyNotes.Services/ManticoreSyncNoteService.cs
@@ -95,14 +95,24 @@ public class ManticoreSyncNoteService(
         }
     }
 
-    public async Task PurgeDeletedNotes()
+    public async Task PurgeDeletedNotes(long userId)
     {
-        // Note: PurgeDeletedNotes is a bulk operation that doesn't operate on individual notes
-        // For now, keep direct call to SearchService as it's not tied to specific note operations
-        // This could be migrated to queue later if needed for consistency
-        logger.LogInformation("PurgeDeletedNotes not yet migrated to queue - this is a bulk operation");
+        try
+        {
+            var payload = new ManticoreSearchSyncPayload
+            {
+                Action = "PURGE",
+                FullContent = string.Empty
+            };
 
-        // TODO: Consider implementing bulk queue operations or keeping direct calls for maintenance operations
-        await Task.CompletedTask;
+            var task = SyncTask.Create("manticoresearch", "PURGE", 0, userId, payload);
+            await syncQueueService.EnqueueAsync("manticoresearch", task);
+
+            logger.LogDebug("Successfully queued ManticoreSearch PURGE for user {UserId}", userId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to queue purge sync to ManticoreSearch for user {UserId}", userId);
+        }
     }
 }

--- a/src/HappyNotes.Services/MastodonSyncNoteService.cs
+++ b/src/HappyNotes.Services/MastodonSyncNoteService.cs
@@ -165,9 +165,9 @@ public class MastodonSyncNoteService(
         await Task.CompletedTask;
     }
 
-    public async Task PurgeDeletedNotes()
+    public Task PurgeDeletedNotes(long userId)
     {
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     private async Task<(List<MastodonSyncedInstance> toBeUpdated, List<MastodonSyncedInstance> toBeRemoved,

--- a/src/HappyNotes.Services/NoteService.cs
+++ b/src/HappyNotes.Services/NoteService.cs
@@ -561,6 +561,24 @@ public class NoteService(
     public async Task PurgeUserDeletedNotes(long userId)
     {
         await noteRepository.PurgeUserDeletedNotes(userId);
+
+        foreach (var syncNoteService in syncNoteServices)
+        {
+#pragma warning disable CS4014 // Fire-and-forget task execution is intentional
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await syncNoteService.PurgeDeletedNotes(userId);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to sync purge deleted notes to service {ServiceType}, user ID: {UserId}",
+                        syncNoteService.GetType().Name, userId);
+                }
+            });
+#pragma warning restore CS4014
+        }
     }
 
     /// <summary>

--- a/src/HappyNotes.Services/SearchService.cs
+++ b/src/HappyNotes.Services/SearchService.cs
@@ -143,18 +143,19 @@ public class SearchService : ISearchService
         }
     }
 
-    public async Task PurgeDeletedNotesFromIndexAsync()
+    public async Task PurgeUserDeletedNotesFromIndexAsync(long userId)
     {
         var deleteQuery = new
         {
             index = "noteindex",
             query = new
             {
-                range = new
+                @bool = new
                 {
-                    deletedat = new
+                    must = new object[]
                     {
-                        gt = 0
+                        new { equals = new Dictionary<string, long> { { "UserId", userId } } },
+                        new { range = new { deletedat = new { gt = 0 } } }
                     }
                 }
             }

--- a/src/HappyNotes.Services/SyncQueue/Handlers/ManticoreSearchSyncHandler.cs
+++ b/src/HappyNotes.Services/SyncQueue/Handlers/ManticoreSearchSyncHandler.cs
@@ -64,6 +64,12 @@ public class ManticoreSearchSyncHandler : ISyncHandler
 
             _logger.LogDebug("Processing ManticoreSearch sync for note {NoteId}, action: {Action}", task.EntityId, payload.Action);
 
+            if (payload.Action == "PURGE")
+            {
+                var purgeSuccess = await HandlePurgeAsync(task.UserId);
+                return purgeSuccess ? SyncResult.Success() : SyncResult.Failure("Failed to PURGE user deleted notes from ManticoreSearch");
+            }
+
             var note = await _noteRepository.Get(task.EntityId);
             if (note is null)
             {
@@ -131,6 +137,21 @@ public class ManticoreSearchSyncHandler : ISyncHandler
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to delete ManticoreSearch index entry for note {NoteId}", note.Id);
+            return false;
+        }
+    }
+
+    private async Task<bool> HandlePurgeAsync(long userId)
+    {
+        try
+        {
+            await _searchService.PurgeUserDeletedNotesFromIndexAsync(userId);
+            _logger.LogDebug("Successfully purged deleted notes from ManticoreSearch index for user {UserId}", userId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to purge deleted notes from ManticoreSearch index for user {UserId}", userId);
             return false;
         }
     }

--- a/src/HappyNotes.Services/TelegramSyncNoteService.cs
+++ b/src/HappyNotes.Services/TelegramSyncNoteService.cs
@@ -139,10 +139,9 @@ public class TelegramSyncNoteService(
         await Task.CompletedTask;
     }
 
-    public async Task PurgeDeletedNotes()
+    public Task PurgeDeletedNotes(long userId)
     {
-        // As per user instruction, no action is taken for purging deleted notes on Telegram
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/HappyNotes.Services/interfaces/ISearchService.cs
+++ b/src/HappyNotes.Services/interfaces/ISearchService.cs
@@ -9,5 +9,5 @@ public interface ISearchService
     Task SyncNoteToIndexAsync(Note note, string fullContent);
     Task DeleteNoteFromIndexAsync(long id);
     Task UndeleteNoteFromIndexAsync(long id);
-    Task PurgeDeletedNotesFromIndexAsync();
+    Task PurgeUserDeletedNotesFromIndexAsync(long userId);
 }

--- a/src/HappyNotes.Services/interfaces/ISyncNoteService.cs
+++ b/src/HappyNotes.Services/interfaces/ISyncNoteService.cs
@@ -8,5 +8,5 @@ public interface ISyncNoteService
     Task SyncEditNote(Note note, string fullContent, Note originalNote);
     Task SyncDeleteNote(Note note);
     Task SyncUndeleteNote(Note note);
-    Task PurgeDeletedNotes();
+    Task PurgeDeletedNotes(long userId);
 }

--- a/tests/HappyNotes.Services.Tests/ManticoreSearchSyncHandlerTests.cs
+++ b/tests/HappyNotes.Services.Tests/ManticoreSearchSyncHandlerTests.cs
@@ -291,6 +291,50 @@ public class ManticoreSearchSyncHandlerTests
     }
 
     [Test]
+    public async Task ProcessAsync_PurgeAction_CallsPurgeUserDeletedNotesFromIndexAsync()
+    {
+        // Arrange
+        var payload = new ManticoreSearchSyncPayload
+        {
+            Action = "PURGE",
+            FullContent = string.Empty
+        };
+        var task = CreateTask("PURGE", 0, 123, payload);
+
+        _mockSearchService.Setup(x => x.PurgeUserDeletedNotesFromIndexAsync(123)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _manticoreSearchSyncHandler.ProcessAsync(task, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsSuccess, Is.True);
+        _mockSearchService.Verify(x => x.PurgeUserDeletedNotesFromIndexAsync(123), Times.Once);
+        _mockNoteRepository.Verify(x => x.Get(It.IsAny<long>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ProcessAsync_PurgeAction_SearchServiceThrows_ReturnsRetryableFailure()
+    {
+        // Arrange
+        var payload = new ManticoreSearchSyncPayload
+        {
+            Action = "PURGE",
+            FullContent = string.Empty
+        };
+        var task = CreateTask("PURGE", 0, 123, payload);
+
+        _mockSearchService.Setup(x => x.PurgeUserDeletedNotesFromIndexAsync(123))
+            .ThrowsAsync(new Exception("ManticoreSearch connection failed"));
+
+        // Act
+        var result = await _manticoreSearchSyncHandler.ProcessAsync(task, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ShouldRetry, Is.True);
+    }
+
+    [Test]
     public async Task ProcessAsync_JsonElementPayload_HandlesCorrectly()
     {
         // Arrange

--- a/tests/HappyNotes.Services.Tests/ManticoreSyncIntegrationTests.cs
+++ b/tests/HappyNotes.Services.Tests/ManticoreSyncIntegrationTests.cs
@@ -1,5 +1,6 @@
 using HappyNotes.Entities;
 using HappyNotes.Services.SyncQueue.Interfaces;
+using HappyNotes.Services.SyncQueue.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -159,13 +160,13 @@ public class ManticoreSyncIntegrationTests
     }
 
     [Test]
-    public async Task PurgeDeletedNotes_MultipleDeletedNotes_RemovesFromIndex()
+    public async Task PurgeDeletedNotes_MultipleDeletedNotes_EnqueuesTask()
     {
         // Act
-        await _syncService.PurgeDeletedNotes();
+        await _syncService.PurgeDeletedNotes(userId: 1);
 
         // Assert
-        // Assume purge succeeded if no exception; in a full test, verify no deleted notes remain in index.
+        _mockSyncQueueService.Verify(s => s.EnqueueAsync("manticoresearch", It.IsAny<SyncTask<ManticoreSearchSyncPayload>>()), Times.Once);
         _mockLogger.Verify(logger => logger.Log(
             It.Is<LogLevel>(level => level == LogLevel.Error),
             It.IsAny<EventId>(),

--- a/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
@@ -324,7 +324,7 @@ public class SearchServiceTests
     }
 
     [Test]
-    public async Task PurgeDeletedNotesFromIndexAsync_DeletedNotes_RemovesThem()
+    public async Task PurgeUserDeletedNotesFromIndexAsync_DeletedNotes_RemovesThem()
     {
         // Arrange
         _mockHandler.Protected()
@@ -340,7 +340,7 @@ public class SearchServiceTests
             });
 
         // Act
-        await _searchService.PurgeDeletedNotesFromIndexAsync();
+        await _searchService.PurgeUserDeletedNotesFromIndexAsync(123);
 
         // Assert
         _mockHandler.Protected().Verify(


### PR DESCRIPTION
Closes #45

## Summary

- Soft-deleted Manticore index docs are now hard-removed per-user when `PurgeDeleted` is called, via the existing Redis sync queue
- Added `PurgeUserDeletedNotesFromIndexAsync(long userId)` to `ISearchService`/`SearchService` — deletes where `UserId=X AND deletedat>0`; removed the dead global `PurgeDeletedNotesFromIndexAsync`
- `ISyncNoteService.PurgeDeletedNotes` now takes `long userId`; `NoteService.PurgeUserDeletedNotes` iterates `syncNoteServices` after the DB purge (mirrors the existing delete/undelete fire-and-forget pattern)
- `ManticoreSyncNoteService.PurgeDeletedNotes(userId)` enqueues a `PURGE` task; `ManticoreSearchSyncHandler` early-dispatches it to `HandlePurgeAsync` without fetching a note entity — other users' docs are untouched
- Two new handler unit tests: PURGE success path and retryable-failure path

## Test plan
- [ ] Unit tests green (`dotnet test --filter "TestCategory!=Integration"`)
- [ ] Confirm `ManticoreSearchSyncHandlerTests.ProcessAsync_PurgeAction_*` pass
- [ ] Confirm `ManticoreSyncIntegrationTests.PurgeDeletedNotes_MultipleDeletedNotes_EnqueuesTask` verifies enqueue (explicit/manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)