### PR TITLE
feat: add Fanfou (饭否) as a sync target (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ The application uses a **Redis-based queue system** for reliable background sync
 ### Supported Services
 - ✅ **Telegram**: Full queue integration with channel management
 - ✅ **Mastodon**: Complete queue integration with instance management
+- ✅ **Fanfou**: Queue integration via OAuth 1.0a; per-user sync rule (all / public-only / `#fanfou` tag)
 - ⏳ **ManticoreSearch**: Not yet migrated (still uses direct sync)
 
 ### Configuration

--- a/documents/database/changelist/2026/07-15-add-fanfou-sync.sql
+++ b/documents/database/changelist/2026/07-15-add-fanfou-sync.sql
@@ -1,0 +1,31 @@
+USE HappyNotes;
+
+CREATE TABLE IF NOT EXISTS FanfouUserAccount
+(
+    Id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    UserId            BIGINT       NOT NULL,
+    FanfouUserId      VARCHAR(255) NOT NULL DEFAULT '',
+    AccessToken       VARCHAR(512) NOT NULL,
+    AccessTokenSecret VARCHAR(512) NOT NULL,
+    Status            INT          NOT NULL COMMENT 'Reference FanfouUserAccountStatus enum for details',
+    SyncType          INT          NOT NULL DEFAULT '1' COMMENT 'FanfouSyncType 1 All 2 PublicOnly 3 TagFanfouOnly',
+    CreatedAt         BIGINT       NOT NULL,
+    UNIQUE KEY (UserId)
+);
+
+-- Check if the 'FanfouStatusIds' field exists on Note
+SELECT COUNT(*)
+INTO @exists
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = 'HappyNotes'
+  AND TABLE_NAME = 'Note'
+  AND COLUMN_NAME = 'FanfouStatusIds';
+
+-- If the 'FanfouStatusIds' field does not exist, add it
+SET @sql = IF(@exists = 0,
+              'ALTER TABLE `HappyNotes`.`Note` ADD `FanfouStatusIds` VARCHAR(512) NULL COMMENT ''Comma-separated UserAccountId:StatusId list'' AFTER `MastodonTootIds`;',
+              'SELECT ''Column FanfouStatusIds already exists.'' AS Result');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/HappyNotes.Api/Controllers/FanfouAuthController.cs
+++ b/src/HappyNotes.Api/Controllers/FanfouAuthController.cs
@@ -1,0 +1,112 @@
+using Api.Framework;
+using Api.Framework.Helper;
+using Api.Framework.Models;
+using Api.Framework.Result;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Models;
+using HappyNotes.Services.interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HappyNotes.Api.Controllers;
+
+[Authorize]
+public class FanfouAuthController(
+    IFanfouService fanfouService,
+    IRepositoryBase<FanfouUserAccount> fanfouUserAccountRepository,
+    IFanfouUserAccountCacheService fanfouUserAccountCacheService,
+    ICurrentUser currentUser,
+    ILogger<FanfouAuthController> logger,
+    IOptions<JwtConfig> jwtConfig,
+    IGeneralMemoryCacheService generalMemoryCacheService) : BaseController
+{
+    private readonly JwtConfig _jwtConfig = jwtConfig.Value;
+
+    // The request-token → user binding is single-use and short-lived so a leaked
+    // oauth_token cannot be replayed to rebind a different account.
+    private static readonly TimeSpan StateTtl = TimeSpan.FromMinutes(10);
+    private static string StateCacheKey(string requestToken) => $"fanfou_oauth_{requestToken}";
+
+    /// <summary>
+    /// First leg: fetch a request token and return the URL the user should be sent to
+    /// in order to authorize the app.
+    /// </summary>
+    [HttpPost]
+    public async Task<ApiResult<string>> RequestToken()
+    {
+        var requestToken = await fanfouService.GetRequestTokenAsync();
+        if (string.IsNullOrEmpty(requestToken.Token))
+        {
+            return new FailedResult<string>(string.Empty, "Failed to obtain Fanfou request token");
+        }
+
+        generalMemoryCacheService.Set(StateCacheKey(requestToken.Token),
+            new FanfouOAuthState { UserId = currentUser.Id, RequestTokenSecret = requestToken.TokenSecret },
+            StateTtl);
+
+        var authorizeUrl = fanfouService.GetAuthorizeUrl(requestToken.Token);
+        logger.LogInformation("Issued Fanfou request token for user {UserId}", currentUser.Id);
+        return new SuccessfulResult<string>(authorizeUrl);
+    }
+
+    /// <summary>
+    /// Final leg: Fanfou redirects here after the user authorizes. Exchange the
+    /// verified request token for access credentials and persist the account.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<ApiResult> Callback(string oauth_token, string oauth_verifier)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(oauth_token))
+            {
+                return Fail("Missing oauth_token");
+            }
+
+            var state = generalMemoryCacheService.Get<FanfouOAuthState>(StateCacheKey(oauth_token));
+            if (state == null || state.UserId == 0)
+            {
+                logger.LogError("Invalid or expired Fanfou oauth_token in callback");
+                return Fail("Invalid or expired authorization state");
+            }
+
+            // Single-use: evict immediately so the token cannot be replayed.
+            generalMemoryCacheService.ClearCache(StateCacheKey(oauth_token));
+
+            var accessToken = await fanfouService.GetAccessTokenAsync(oauth_token, state.RequestTokenSecret, oauth_verifier);
+            if (string.IsNullOrEmpty(accessToken.Token) || string.IsNullOrEmpty(accessToken.TokenSecret))
+            {
+                logger.LogError("Fanfou access token exchange returned empty credentials for user {UserId}", state.UserId);
+                return Fail("Failed to obtain Fanfou access token");
+            }
+
+            // A user has a single Fanfou account; replace any previous linkage.
+            await fanfouUserAccountRepository.DeleteAsync(a => a.UserId == state.UserId);
+
+            var account = new FanfouUserAccount
+            {
+                UserId = state.UserId,
+                FanfouUserId = accessToken.UserId,
+                AccessToken = TextEncryptionHelper.Encrypt(accessToken.Token, _jwtConfig.SymmetricSecurityKey),
+                AccessTokenSecret = TextEncryptionHelper.Encrypt(accessToken.TokenSecret, _jwtConfig.SymmetricSecurityKey),
+                Status = FanfouUserAccountStatus.Normal,
+                SyncType = FanfouSyncType.All,
+                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            };
+            await fanfouUserAccountRepository.InsertAsync(account);
+            fanfouUserAccountCacheService.ClearCache(state.UserId);
+
+            logger.LogInformation("Successfully linked Fanfou account for user {UserId}", state.UserId);
+            return Success("Successfully authenticated with Fanfou. You can close this page.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Fanfou OAuth callback failed: {ErrorMessage}", ex.Message);
+            return Fail($"Authentication failed: {ex.Message}");
+        }
+    }
+}

--- a/src/HappyNotes.Api/Controllers/FanfouUserAccountController.cs
+++ b/src/HappyNotes.Api/Controllers/FanfouUserAccountController.cs
@@ -1,0 +1,103 @@
+using Api.Framework;
+using Api.Framework.Extensions;
+using Api.Framework.Result;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Services.interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HappyNotes.Api.Controllers;
+
+[Authorize]
+public class FanfouUserAccountController(
+    ICurrentUser currentUser,
+    IRepositoryBase<FanfouUserAccount> fanfouUserAccountsRepository,
+    IFanfouUserAccountCacheService fanfouUserAccountsCacheService
+) : BaseController
+{
+    // A user has a single Fanfou account; GetAll returns a list for parity with
+    // the Mastodon settings shape the frontend consumes.
+    [HttpGet]
+    public async Task<ApiResult<List<FanfouUserAccount>>> GetAll()
+    {
+        var userId = currentUser.Id;
+        var settings = await fanfouUserAccountsRepository.GetListAsync(s => s.UserId.Equals(userId), o => o.CreatedAt);
+        return new SuccessfulResult<List<FanfouUserAccount>>(settings.ToList());
+    }
+
+    [HttpPost]
+    public async Task<ApiResult> Disable()
+    {
+        var userId = currentUser.Id;
+        var existingSetting = await fanfouUserAccountsRepository.GetFirstOrDefaultAsync(s => s.UserId == userId);
+        if (existingSetting == null)
+        {
+            throw new Exception("No Fanfou account exists for the current user.");
+        }
+
+        if (existingSetting.Status.Has(FanfouUserAccountStatus.Inactive))
+        {
+            throw new Exception("Fanfou account is already Disabled");
+        }
+
+        existingSetting.Status = existingSetting.Status.Add(FanfouUserAccountStatus.Inactive);
+
+        var result = await fanfouUserAccountsRepository.UpdateAsync(existingSetting);
+        if (result) fanfouUserAccountsCacheService.ClearCache(userId);
+        return result ? Success() : new FailedResult<bool>(false, "0 rows Updated");
+    }
+
+    [HttpPost]
+    public async Task<ApiResult<bool>> Activate()
+    {
+        var userId = currentUser.Id;
+        var existingSetting = await fanfouUserAccountsRepository.GetFirstOrDefaultAsync(s => s.UserId == userId);
+        if (existingSetting == null)
+        {
+            throw new Exception("No Fanfou account exists for the current user.");
+        }
+
+        if (!existingSetting.Status.Has(FanfouUserAccountStatus.Inactive))
+        {
+            throw new Exception("Fanfou account is already active");
+        }
+
+        existingSetting.Status = existingSetting.Status.Remove(FanfouUserAccountStatus.Inactive);
+
+        var result = await fanfouUserAccountsRepository.UpdateAsync(existingSetting);
+        if (result) fanfouUserAccountsCacheService.ClearCache(userId);
+        return result ? new SuccessfulResult<bool>(true) : new FailedResult<bool>(false, "0 rows Updated");
+    }
+
+    [HttpPost]
+    public async Task<ApiResult<bool>> NextSyncType()
+    {
+        var userId = currentUser.Id;
+        var existingSetting = await fanfouUserAccountsRepository.GetFirstOrDefaultAsync(s => s.UserId == userId);
+        if (existingSetting == null)
+        {
+            throw new Exception("No Fanfou account exists for the current user.");
+        }
+
+        existingSetting.SyncType = existingSetting.SyncType.Next();
+        var result = await fanfouUserAccountsRepository.UpdateAsync(existingSetting);
+        if (result) fanfouUserAccountsCacheService.ClearCache(userId);
+        return result ? new SuccessfulResult<bool>(true) : new FailedResult<bool>(false, "0 rows Updated");
+    }
+
+    [HttpDelete]
+    public async Task<ApiResult<bool>> Delete()
+    {
+        var userId = currentUser.Id;
+        var existingSetting = await fanfouUserAccountsRepository.GetFirstOrDefaultAsync(s => s.UserId == userId);
+        if (existingSetting == null)
+        {
+            throw new Exception("Fanfou account has already been Deleted");
+        }
+
+        var result = await fanfouUserAccountsRepository.DeleteAsync(s => s.UserId == userId);
+        if (result) fanfouUserAccountsCacheService.ClearCache(userId);
+        return result ? new SuccessfulResult<bool>(true) : new FailedResult<bool>(false, "0 rows deleted");
+    }
+}

--- a/src/HappyNotes.Api/Program.cs
+++ b/src/HappyNotes.Api/Program.cs
@@ -141,6 +141,7 @@ void ConfigAuthentication(WebApplicationBuilder b)
     var configuration = b.Configuration;
     services.Configure<JwtConfig>(configuration.GetSection("Jwt"));
     services.Configure<GoogleOAuthConfig>(configuration.GetSection("GoogleOAuth"));
+    services.Configure<FanfouConfig>(configuration.GetSection("Fanfou"));
     var jwtConfig = configuration.GetSection("Jwt").Get<JwtConfig>();
     services.AddAuthentication(options =>
         {

--- a/src/HappyNotes.Api/ServiceExtensions.cs
+++ b/src/HappyNotes.Api/ServiceExtensions.cs
@@ -20,11 +20,14 @@ public static class ServiceExtensions
         services.AddScoped<INoteRepository, NoteRepository>();
         services.AddSingleton<ITelegramService, TelegramService>();
         services.AddSingleton<IMastodonTootService, MastodonTootService>();
+        services.AddSingleton<IFanfouService, FanfouService>();
         services.AddSingleton<IMemoryCache, MemoryCache>();
         services.AddScoped<ITelegramSettingsCacheService, TelegramSettingsCacheService>();
         services.AddScoped<IMastodonUserAccountCacheService, MastodonUserAccountCacheService>();
+        services.AddScoped<IFanfouUserAccountCacheService, FanfouUserAccountCacheService>();
         services.AddSingleton<IGeneralMemoryCacheService, GeneralMemoryCacheService>();
         services.AddScoped<ISyncNoteService, MastodonSyncNoteService>();
+        services.AddScoped<ISyncNoteService, FanfouSyncNoteService>();
         services.AddScoped<ISyncNoteService, TelegramSyncNoteService>();
         services.AddScoped<ISyncNoteService, ManticoreSyncNoteService>();
         services.AddScoped<ISearchService, SearchService>();

--- a/src/HappyNotes.Api/appsettings.json
+++ b/src/HappyNotes.Api/appsettings.json
@@ -18,6 +18,13 @@
   "GoogleOAuth": {
     "ClientId": "58546417130-pfhegondiq6jsddc72lknvou7g2o3bpq.apps.googleusercontent.com"
   },
+  "Fanfou": {
+    "ConsumerKey": "fanfou-consumer-key-placeholder",
+    "ConsumerSecret": "fanfou-consumer-secret-placeholder",
+    "ApiBaseUrl": "https://api.fanfou.com",
+    "OAuthBaseUrl": "https://fanfou.com",
+    "CallbackUrl": "https://happynotes.shukebeta.com/fanfou/callback"
+  },
   "DatabaseConnectionOptions": {
     "ConnectionString": "server=default_mysql_server; port=6306; uid=default_user; password=password-placeholder; database=HappyNotes; charset=utf8mb4;",
     "DbType":"MySql",
@@ -56,6 +63,12 @@
     },
     "Handlers": {
       "telegram": {
+        "maxRetries": 3,
+        "baseDelaySeconds": 60,
+        "backoffMultiplier": 2.0,
+        "maxDelayMinutes": 60
+      },
+      "fanfou": {
         "maxRetries": 3,
         "baseDelaySeconds": 60,
         "backoffMultiplier": 2.0,

--- a/src/HappyNotes.Common/Constants.cs
+++ b/src/HappyNotes.Common/Constants.cs
@@ -7,6 +7,7 @@ public static class Constants
     public const int MaxPageSize = 60;
     public const int TelegramMessageLength = 4096;
     public const int MastodonTootLength = 500;
+    public const int FanfouStatusLength = 140;
     public const int TelegramCaptionLength = 1024;
     public const string TelegramSameTokenFlag = "the same token as the last setting";
     public const string MastodonAppName = "HappyNotes";
@@ -15,10 +16,11 @@ public static class Constants
     // Sync service names
     public const string TelegramService = "telegram";
     public const string MastodonService = "mastodon";
+    public const string FanfouService = "fanfou";
     public const string ManticoreSearchService = "manticoresearch";
 
     /// <summary>
     /// All available sync services
     /// </summary>
-    public static readonly string[] AllSyncServices = { TelegramService, MastodonService, ManticoreSearchService };
+    public static readonly string[] AllSyncServices = { TelegramService, MastodonService, FanfouService, ManticoreSearchService };
 }

--- a/src/HappyNotes.Common/Enums/FanfouSyncType.cs
+++ b/src/HappyNotes.Common/Enums/FanfouSyncType.cs
@@ -1,0 +1,33 @@
+namespace HappyNotes.Common.Enums;
+
+public enum FanfouSyncType
+{
+    /// <summary>
+    /// Sync all notes
+    /// </summary>
+    All = 1,
+
+    /// <summary>
+    /// Public notes only
+    /// </summary>
+    PublicOnly = 2,
+
+    /// <summary>
+    /// Sync notes that have a fanfou tag
+    /// </summary>
+    TagFanfouOnly = 3,
+}
+
+public static class FanfouSyncTypeExtensions
+{
+    public static FanfouSyncType Next(this FanfouSyncType syncType)
+    {
+        return syncType switch
+        {
+            FanfouSyncType.All => FanfouSyncType.PublicOnly,
+            FanfouSyncType.PublicOnly => FanfouSyncType.TagFanfouOnly,
+            FanfouSyncType.TagFanfouOnly => FanfouSyncType.All,
+            _ => FanfouSyncType.All,
+        };
+    }
+}

--- a/src/HappyNotes.Common/Enums/FanfouUserAccountStatus.cs
+++ b/src/HappyNotes.Common/Enums/FanfouUserAccountStatus.cs
@@ -1,0 +1,19 @@
+namespace HappyNotes.Common.Enums;
+
+public enum FanfouUserAccountStatus
+{
+    /// <summary>
+    /// The initial status.
+    /// </summary>
+    Normal = 1,
+
+    /// <summary>
+    /// Temporarily deactivated.
+    /// </summary>
+    Inactive = 2,
+
+    /// <summary>
+    /// Alias for disabled setting (Created, Tested, and Inactive).
+    /// </summary>
+    Disabled = Normal | Inactive,
+}

--- a/src/HappyNotes.Entities/FanfouUserAccount.cs
+++ b/src/HappyNotes.Entities/FanfouUserAccount.cs
@@ -1,0 +1,44 @@
+using Api.Framework.Helper;
+using HappyNotes.Common.Enums;
+using SqlSugar;
+
+namespace HappyNotes.Entities;
+
+public class FanfouUserAccount
+{
+    [SugarColumn(IsPrimaryKey = true, IsIdentity = true)]
+    public long Id { get; set; }
+
+    public long UserId { get; set; }
+
+    /// <summary>
+    /// The Fanfou account id (the authorizing user's Fanfou id/screen name).
+    /// </summary>
+    public string FanfouUserId { get; set; } = string.Empty;
+
+    public string AccessToken { get; init; } = string.Empty;
+    public string AccessTokenSecret { get; init; } = string.Empty;
+
+    public FanfouUserAccountStatus Status { get; set; }
+    public FanfouSyncType SyncType { get; set; } = FanfouSyncType.All;
+
+    /// <summary>
+    /// Gets the status text representation of the current status.
+    /// </summary>
+    [SugarColumn(IsIgnore = true)]
+    public string StatusText => Status.ToString();
+
+    public long CreatedAt { get; set; }
+
+    private string? _decryptedAccessToken;
+    public string DecryptedAccessToken(string key)
+    {
+        return _decryptedAccessToken ??= TextEncryptionHelper.Decrypt(AccessToken, key);
+    }
+
+    private string? _decryptedAccessTokenSecret;
+    public string DecryptedAccessTokenSecret(string key)
+    {
+        return _decryptedAccessTokenSecret ??= TextEncryptionHelper.Decrypt(AccessTokenSecret, key);
+    }
+}

--- a/src/HappyNotes.Entities/Note.cs
+++ b/src/HappyNotes.Entities/Note.cs
@@ -16,6 +16,7 @@ public class Note : EntityBase
     public string Tags { get; set; } = string.Empty;
     public string? TelegramMessageIds { get; set; }
     public string? MastodonTootIds { get; set; }
+    public string? FanfouStatusIds { get; set; }
 
     [SugarColumn(IsIgnore = true)] public User User { get; set; } = default!;
     [SugarColumn(IsIgnore = true)] public List<string> TagList { get; set; } = [];
@@ -23,6 +24,10 @@ public class Note : EntityBase
     public void UpdateMastodonInstanceIds(List<MastodonSyncedInstance> instances)
     {
         MastodonTootIds = string.Join(",", instances.Select(r => $"{r.UserAccountId}:{r.TootId}"));
+    }
+    public void UpdateFanfouInstanceIds(List<FanfouSyncedInstance> instances)
+    {
+        FanfouStatusIds = string.Join(",", instances.Select(r => $"{r.UserAccountId}:{r.StatusId}"));
     }
     public void UpdateTelegramMessageIds(List<SyncedTelegramChannel> channels)
     {
@@ -68,5 +73,46 @@ public class Note : EntityBase
         tootIds.RemoveAll(id => id.Equals(targetId, StringComparison.OrdinalIgnoreCase));
 
         MastodonTootIds = tootIds.Any() ? string.Join(",", tootIds) : null;
+    }
+
+    public void AddFanfouStatusId(long userAccountId, string statusId)
+    {
+        var statusIdEntry = $"{userAccountId}:{statusId}";
+
+        if (string.IsNullOrWhiteSpace(FanfouStatusIds))
+        {
+            FanfouStatusIds = statusIdEntry;
+        }
+        else
+        {
+            var statusIds = FanfouStatusIds.Split(',').ToList();
+            var existingIndex = statusIds.FindIndex(id => id.StartsWith($"{userAccountId}:"));
+
+            if (existingIndex >= 0)
+            {
+                statusIds[existingIndex] = statusIdEntry;
+            }
+            else
+            {
+                statusIds.Add(statusIdEntry);
+            }
+
+            FanfouStatusIds = string.Join(",", statusIds);
+        }
+    }
+
+    public void RemoveFanfouStatusId(long userAccountId, string statusId)
+    {
+        if (string.IsNullOrWhiteSpace(FanfouStatusIds))
+        {
+            return;
+        }
+
+        var statusIds = FanfouStatusIds.Split(',').ToList();
+        var targetId = $"{userAccountId}:{statusId}";
+
+        statusIds.RemoveAll(id => id.Equals(targetId, StringComparison.OrdinalIgnoreCase));
+
+        FanfouStatusIds = statusIds.Any() ? string.Join(",", statusIds) : null;
     }
 }

--- a/src/HappyNotes.Models/FanfouOAuthState.cs
+++ b/src/HappyNotes.Models/FanfouOAuthState.cs
@@ -1,0 +1,12 @@
+namespace HappyNotes.Models;
+
+/// <summary>
+/// Server-side state bound to an OAuth 1.0a request token between the authorize
+/// and callback legs: which user started the flow and the request token secret
+/// needed to sign the access-token exchange. Cached single-use with a short TTL.
+/// </summary>
+public class FanfouOAuthState
+{
+    public long UserId { get; set; }
+    public string RequestTokenSecret { get; set; } = string.Empty;
+}

--- a/src/HappyNotes.Models/FanfouSyncedInstance.cs
+++ b/src/HappyNotes.Models/FanfouSyncedInstance.cs
@@ -1,0 +1,7 @@
+namespace HappyNotes.Models;
+
+public class FanfouSyncedInstance
+{
+    public long UserAccountId { get; set; }
+    public string StatusId { get; set; } = string.Empty;
+}

--- a/src/HappyNotes.Models/FanfouTokens.cs
+++ b/src/HappyNotes.Models/FanfouTokens.cs
@@ -1,0 +1,21 @@
+namespace HappyNotes.Models;
+
+/// <summary>
+/// OAuth 1.0a temporary (request) credentials returned from the first leg.
+/// </summary>
+public class FanfouRequestToken
+{
+    public string Token { get; set; } = string.Empty;
+    public string TokenSecret { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// OAuth 1.0a access credentials returned from the final leg.
+/// </summary>
+public class FanfouAccessToken
+{
+    public string Token { get; set; } = string.Empty;
+    public string TokenSecret { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string ScreenName { get; set; } = string.Empty;
+}

--- a/src/HappyNotes.Services/FanfouConfig.cs
+++ b/src/HappyNotes.Services/FanfouConfig.cs
@@ -1,0 +1,30 @@
+namespace HappyNotes.Services
+{
+    /// <summary>
+    /// Fanfou is a single service (api.fanfou.com), so the app-level OAuth 1.0a
+    /// consumer credentials live in configuration (injected at deploy time,
+    /// never committed) rather than in a per-instance database table.
+    /// </summary>
+    public class FanfouConfig
+    {
+        public string ConsumerKey { get; set; } = string.Empty;
+        public string ConsumerSecret { get; set; } = string.Empty;
+
+        /// <summary>
+        /// API base url for signed status calls, e.g. https://api.fanfou.com
+        /// </summary>
+        public string ApiBaseUrl { get; set; } = "https://api.fanfou.com";
+
+        /// <summary>
+        /// OAuth handshake base url (request_token / authorize / access_token),
+        /// e.g. https://fanfou.com
+        /// </summary>
+        public string OAuthBaseUrl { get; set; } = "https://fanfou.com";
+
+        /// <summary>
+        /// OAuth callback url registered with the Fanfou app; where Fanfou
+        /// redirects after the user authorizes.
+        /// </summary>
+        public string CallbackUrl { get; set; } = string.Empty;
+    }
+}

--- a/src/HappyNotes.Services/FanfouService.cs
+++ b/src/HappyNotes.Services/FanfouService.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using HappyNotes.Common;
+using HappyNotes.Models;
+using HappyNotes.Services.interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HappyNotes.Services;
+
+public class FanfouService(
+    IHttpClientFactory httpClientFactory,
+    IOptions<FanfouConfig> fanfouConfig,
+    ILogger<FanfouService> logger
+) : IFanfouService
+{
+    private readonly FanfouConfig _config = fanfouConfig.Value;
+
+    private string RequestTokenUrl => $"{_config.OAuthBaseUrl}/oauth/request_token";
+    private string AuthorizeUrl => $"{_config.OAuthBaseUrl}/oauth/authorize";
+    private string AccessTokenUrl => $"{_config.OAuthBaseUrl}/oauth/access_token";
+    private string UpdateStatusUrl => $"{_config.ApiBaseUrl}/statuses/update.json";
+    private string DestroyStatusUrl => $"{_config.ApiBaseUrl}/statuses/destroy.json";
+
+    public async Task<FanfouRequestToken> GetRequestTokenAsync()
+    {
+        var callback = string.IsNullOrEmpty(_config.CallbackUrl) ? "oob" : _config.CallbackUrl;
+        var authHeader = OAuth1Helper.Sign(
+            "GET", RequestTokenUrl, _config.ConsumerKey, _config.ConsumerSecret,
+            token: null, tokenSecret: null, callback: callback);
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, RequestTokenUrl);
+        request.Headers.TryAddWithoutValidation("Authorization", authHeader);
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError("Fanfou request_token failed. Status: {StatusCode}, Body: {Body}", response.StatusCode, body);
+            throw new Exception($"Fanfou request_token failed: {response.StatusCode}");
+        }
+
+        var parsed = ParseFormEncoded(body);
+        return new FanfouRequestToken
+        {
+            Token = parsed.GetValueOrDefault("oauth_token", string.Empty),
+            TokenSecret = parsed.GetValueOrDefault("oauth_token_secret", string.Empty),
+        };
+    }
+
+    public string GetAuthorizeUrl(string requestToken)
+    {
+        var url = $"{AuthorizeUrl}?oauth_token={Uri.EscapeDataString(requestToken)}";
+        if (!string.IsNullOrEmpty(_config.CallbackUrl))
+        {
+            url += $"&oauth_callback={Uri.EscapeDataString(_config.CallbackUrl)}";
+        }
+
+        return url;
+    }
+
+    public async Task<FanfouAccessToken> GetAccessTokenAsync(string requestToken, string requestTokenSecret, string verifier)
+    {
+        var authHeader = OAuth1Helper.Sign(
+            "GET", AccessTokenUrl, _config.ConsumerKey, _config.ConsumerSecret,
+            token: requestToken, tokenSecret: requestTokenSecret, verifier: verifier);
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, AccessTokenUrl);
+        request.Headers.TryAddWithoutValidation("Authorization", authHeader);
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError("Fanfou access_token failed. Status: {StatusCode}, Body: {Body}", response.StatusCode, body);
+            throw new Exception($"Fanfou access_token failed: {response.StatusCode}");
+        }
+
+        var parsed = ParseFormEncoded(body);
+        return new FanfouAccessToken
+        {
+            Token = parsed.GetValueOrDefault("oauth_token", string.Empty),
+            TokenSecret = parsed.GetValueOrDefault("oauth_token_secret", string.Empty),
+            UserId = parsed.GetValueOrDefault("user_id", string.Empty),
+            ScreenName = parsed.GetValueOrDefault("screen_name", string.Empty),
+        };
+    }
+
+    public async Task<string> SendStatusAsync(string accessToken, string accessTokenSecret, string content, long noteId = 0)
+    {
+        var status = PrepareStatusText(content, noteId);
+        var bodyParams = new Dictionary<string, string> { ["status"] = status };
+
+        var json = await PostSignedAsync(UpdateStatusUrl, accessToken, accessTokenSecret, bodyParams);
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.TryGetProperty("id", out var idElement))
+        {
+            return idElement.ValueKind == JsonValueKind.String
+                ? idElement.GetString() ?? string.Empty
+                : idElement.GetRawText();
+        }
+
+        throw new Exception("Fanfou statuses/update response missing status id");
+    }
+
+    public async Task DeleteStatusAsync(string accessToken, string accessTokenSecret, string statusId)
+    {
+        var bodyParams = new Dictionary<string, string> { ["id"] = statusId };
+        await PostSignedAsync(DestroyStatusUrl, accessToken, accessTokenSecret, bodyParams);
+    }
+
+    private async Task<string> PostSignedAsync(string url, string accessToken, string accessTokenSecret,
+        Dictionary<string, string> bodyParams)
+    {
+        // Form body params participate in the OAuth signature.
+        var authHeader = OAuth1Helper.Sign(
+            "POST", url, _config.ConsumerKey, _config.ConsumerSecret,
+            token: accessToken, tokenSecret: accessTokenSecret, requestParams: bodyParams);
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new FormUrlEncodedContent(bodyParams)
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", authHeader);
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError("Fanfou POST {Url} failed. Status: {StatusCode}, Body: {Body}", url, response.StatusCode, body);
+            throw new Exception($"Fanfou request to {url} failed: {response.StatusCode}");
+        }
+
+        return body;
+    }
+
+    /// <summary>
+    /// Fanfou statuses have a hard 140-character limit. Over-length notes are
+    /// truncated with a trailing permalink back to the note; the link length is
+    /// reserved inside the 140-char budget so the whole status never overflows.
+    /// </summary>
+    internal static string PrepareStatusText(string content, long noteId)
+    {
+        content = content.Trim();
+        if (content.Length <= Constants.FanfouStatusLength)
+        {
+            return content;
+        }
+
+        if (noteId <= 0)
+        {
+            return content[..Constants.FanfouStatusLength];
+        }
+
+        var link = $"{Constants.HappyNotesWebsite}/note/{noteId}";
+        var suffix = $"… {link}";
+
+        // If the link alone leaves no room for content, fall back to a hard truncate.
+        if (suffix.Length >= Constants.FanfouStatusLength)
+        {
+            return content[..Constants.FanfouStatusLength];
+        }
+
+        var headLength = Constants.FanfouStatusLength - suffix.Length;
+        return content[..headLength].TrimEnd() + suffix;
+    }
+
+    private static Dictionary<string, string> ParseFormEncoded(string body)
+    {
+        return body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(p => p.Split('=', 2))
+            .ToDictionary(
+                kv => Uri.UnescapeDataString(kv[0]),
+                kv => kv.Length > 1 ? Uri.UnescapeDataString(kv[1]) : string.Empty);
+    }
+}

--- a/src/HappyNotes.Services/FanfouSyncNoteService.cs
+++ b/src/HappyNotes.Services/FanfouSyncNoteService.cs
@@ -1,0 +1,252 @@
+using HappyNotes.Common;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Models;
+using HappyNotes.Services.interfaces;
+using HappyNotes.Services.SyncQueue.Interfaces;
+using HappyNotes.Services.SyncQueue.Models;
+using Microsoft.Extensions.Logging;
+
+namespace HappyNotes.Services;
+
+public class FanfouSyncNoteService(
+    IFanfouUserAccountCacheService fanfouUserAccountCacheService,
+    ISyncQueueService syncQueueService,
+    ILogger<FanfouSyncNoteService> logger
+)
+    : ISyncNoteService
+{
+    public async Task SyncNewNote(Note note, string fullContent)
+    {
+        logger.LogInformation("Starting sync of new note {NoteId} for user {UserId} to Fanfou. ContentLength: {ContentLength}, IsPrivate: {IsPrivate}",
+            note.Id, note.UserId, fullContent.Length, note.IsPrivate);
+
+        try
+        {
+            var accounts = await _GetToSyncFanfouUserAccounts(note);
+            if (accounts.Any())
+            {
+                foreach (var account in accounts)
+                {
+                    await EnqueueSyncTask(note, fullContent, account, "CREATE");
+                    logger.LogDebug("Queued CREATE task for note {NoteId} to Fanfou account {AccountId}",
+                        note.Id, account.Id);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error in SyncNewNote (Fanfou) for note {NoteId}", note.Id);
+        }
+    }
+
+    public async Task SyncEditNote(Note note, string fullContent, Note existingNote)
+    {
+        logger.LogInformation("Starting sync edit of note {NoteId} for user {UserId} to Fanfou. ContentLength: {ContentLength}, IsPrivate: {IsPrivate}",
+            note.Id, note.UserId, fullContent.Length, note.IsPrivate);
+
+        try
+        {
+            var hasContentChange = _HasContentChanged(existingNote, note, fullContent);
+            var accounts = await fanfouUserAccountCacheService.GetAsync(note.UserId);
+            if (!accounts.Any())
+            {
+                logger.LogDebug("No Fanfou accounts found for user {UserId}, skipping sync edit of note {NoteId}",
+                    note.UserId, note.Id);
+                return;
+            }
+
+            var syncedInstances = _GetSyncedInstances(note);
+            var toSyncAccounts = await _GetToSyncFanfouUserAccounts(note);
+
+            var toBeUpdated = _GetInstancesToBeUpdated(syncedInstances, toSyncAccounts);
+            var toBeRemoved = _GetInstancesToBeRemoved(syncedInstances, toSyncAccounts);
+            var toBeSent = _GetAccountsToBeSent(syncedInstances, toSyncAccounts);
+
+            logger.LogDebug("Edit sync plan for note {NoteId} (Fanfou): {ToSendCount} to send, {ToUpdateCount} to update, {ToRemoveCount} to remove",
+                note.Id, toBeSent.Count, toBeUpdated.Count, toBeRemoved.Count);
+
+            foreach (var instance in toBeRemoved)
+            {
+                var account = accounts.FirstOrDefault(s => s.Id.Equals(instance.UserAccountId));
+                if (account != null)
+                {
+                    await EnqueueSyncTask(note, string.Empty, account, "DELETE", instance.StatusId);
+                }
+            }
+
+            foreach (var instance in toBeUpdated)
+            {
+                var account = accounts.FirstOrDefault(s => s.Id.Equals(instance.UserAccountId));
+                if (account == null) continue;
+                if (hasContentChange)
+                {
+                    await EnqueueSyncTask(note, fullContent, account, "UPDATE", instance.StatusId);
+                }
+            }
+
+            foreach (var account in toBeSent)
+            {
+                await EnqueueSyncTask(note, fullContent, account, "CREATE");
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error in SyncEditNote (Fanfou) for note {NoteId}", note.Id);
+        }
+    }
+
+    public async Task SyncDeleteNote(Note note)
+    {
+        logger.LogInformation("Starting sync delete of note {NoteId} for user {UserId} from Fanfou", note.Id, note.UserId);
+
+        if (string.IsNullOrWhiteSpace(note.FanfouStatusIds))
+        {
+            logger.LogDebug("Note {NoteId} has no Fanfou sync data, nothing to delete", note.Id);
+            return;
+        }
+
+        try
+        {
+            var accounts = await fanfouUserAccountCacheService.GetAsync(note.UserId);
+            if (!accounts.Any())
+            {
+                logger.LogDebug("No Fanfou accounts found for user {UserId}, skipping sync delete of note {NoteId}",
+                    note.UserId, note.Id);
+                return;
+            }
+
+            var syncedInstances = _GetSyncedInstances(note);
+            foreach (var instance in syncedInstances)
+            {
+                var account = accounts.FirstOrDefault(s => s.Id.Equals(instance.UserAccountId));
+                if (account != null)
+                {
+                    await EnqueueSyncTask(note, string.Empty, account, "DELETE", instance.StatusId);
+                }
+                else
+                {
+                    logger.LogWarning("Account {AccountId} not found for deleting Fanfou status {StatusId} from note {NoteId}",
+                        instance.UserAccountId, instance.StatusId, note.Id);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error enqueueing Fanfou delete tasks for note {NoteId}", note.Id);
+        }
+    }
+
+    public async Task SyncUndeleteNote(Note note)
+    {
+        await Task.CompletedTask;
+    }
+
+    public Task PurgeDeletedNotes(long userId)
+    {
+        return Task.CompletedTask;
+    }
+
+    private async Task<IList<FanfouUserAccount>> _GetToSyncFanfouUserAccounts(Note note)
+    {
+        var result = new List<FanfouUserAccount>();
+        var all = await fanfouUserAccountCacheService.GetAsync(note.UserId);
+        foreach (var account in all)
+        {
+            switch (account.SyncType)
+            {
+                case FanfouSyncType.All:
+                    result.Add(account);
+                    break;
+                case FanfouSyncType.PublicOnly:
+                    if (!note.IsPrivate)
+                    {
+                        result.Add(account);
+                    }
+
+                    break;
+                case FanfouSyncType.TagFanfouOnly:
+                    if (note.TagList.Contains("fanfou"))
+                    {
+                        result.Add(account);
+                    }
+
+                    break;
+            }
+        }
+
+        return result;
+    }
+
+    private List<FanfouSyncedInstance> _GetInstancesToBeUpdated(List<FanfouSyncedInstance> instances,
+        IList<FanfouUserAccount> toSyncAccounts)
+    {
+        var idsToUpdate = instances.Select(i => i.UserAccountId).Intersect(toSyncAccounts.Select(t => t.Id)).ToList();
+        return instances.Where(r => idsToUpdate.Contains(r.UserAccountId)).ToList();
+    }
+
+    private List<FanfouSyncedInstance> _GetInstancesToBeRemoved(List<FanfouSyncedInstance> instances,
+        IList<FanfouUserAccount> toSyncAccounts)
+    {
+        if (!toSyncAccounts.Any()) return instances;
+
+        var idsToRemove = instances.Select(s => s.UserAccountId).Except(toSyncAccounts.Select(t => t.Id)).ToList();
+        return instances.Where(r => idsToRemove.Contains(r.UserAccountId)).ToList();
+    }
+
+    private List<FanfouUserAccount> _GetAccountsToBeSent(List<FanfouSyncedInstance> syncedInstances,
+        IList<FanfouUserAccount> toSyncAccounts)
+    {
+        if (!syncedInstances.Any()) return toSyncAccounts.ToList();
+        var toSendUserAccountId = toSyncAccounts.Select(t => t.Id).Except(syncedInstances.Select(s => s.UserAccountId))
+            .ToList();
+        return toSyncAccounts.Where(t => toSendUserAccountId.Contains(t.Id)).ToList();
+    }
+
+    private async Task EnqueueSyncTask(Note note, string fullContent, FanfouUserAccount account, string action, string? statusId = null)
+    {
+        var payload = new FanfouSyncPayload
+        {
+            UserAccountId = account.Id,
+            FullContent = fullContent,
+            StatusId = statusId,
+            IsPrivate = note.IsPrivate,
+            IsMarkdown = note.IsMarkdown
+        };
+
+        var task = SyncTask.Create(Constants.FanfouService, action, note.Id, note.UserId, payload);
+        await syncQueueService.EnqueueAsync(Constants.FanfouService, task);
+
+        logger.LogInformation("Enqueued Fanfou sync task {TaskId} for note {NoteId}, action: {Action}, account: {AccountId}",
+            task.Id, note.Id, action, account.Id);
+    }
+
+    private static List<FanfouSyncedInstance> _GetSyncedInstances(Note note)
+    {
+        if (string.IsNullOrWhiteSpace(note.FanfouStatusIds)) return new List<FanfouSyncedInstance>();
+        return note.FanfouStatusIds.Split(",").Select(s =>
+        {
+            var sync = s.Split(":");
+            return new FanfouSyncedInstance
+            {
+                UserAccountId = long.Parse(sync[0]),
+                StatusId = sync[1],
+            };
+        }).ToList();
+    }
+
+    private bool _HasContentChanged(Note existingNote, Note newNote, string newFullContent)
+    {
+        if (existingNote.Content != newFullContent)
+        {
+            return true;
+        }
+
+        if (existingNote.IsMarkdown != newNote.IsMarkdown)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/HappyNotes.Services/FanfouUserAccountCacheService.cs
+++ b/src/HappyNotes.Services/FanfouUserAccountCacheService.cs
@@ -1,0 +1,44 @@
+using Api.Framework;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Services.interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace HappyNotes.Services;
+
+public class FanfouUserAccountCacheService(
+    IMemoryCache cache,
+    IRepositoryBase<FanfouUserAccount> fanfouUserAccountsRepository)
+    : IFanfouUserAccountCacheService
+{
+    private static string CacheKey(long userId) => $"FUA_{userId}";
+
+    // Set cache options
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetSlidingExpiration(TimeSpan.FromMinutes(1440)); // Set expiration time
+
+    public async Task<IList<FanfouUserAccount>> GetAsync(long userId)
+    {
+        if (cache.TryGetValue(CacheKey(userId), out List<FanfouUserAccount>? config))
+        {
+            return config!;
+        }
+
+        // If not in cache, load from the database
+        var settings = await fanfouUserAccountsRepository.GetListAsync(
+            s => s.UserId == userId && s.Status == FanfouUserAccountStatus.Normal);
+
+        Set(userId, settings);
+        return settings;
+    }
+
+    public void Set(long userId, IList<FanfouUserAccount> account)
+    {
+        cache.Set(CacheKey(userId), account, CacheEntryOptions);
+    }
+
+    public void ClearCache(long userId)
+    {
+        cache.Remove(CacheKey(userId));
+    }
+}

--- a/src/HappyNotes.Services/OAuth1Helper.cs
+++ b/src/HappyNotes.Services/OAuth1Helper.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace HappyNotes.Services;
+
+/// <summary>
+/// Minimal OAuth 1.0a (HMAC-SHA1) request signer per RFC 5849. Fanfou has no
+/// maintained .NET SDK, so this builds the signed <c>Authorization</c> header
+/// used for the three-legged OAuth handshake and for signed API calls.
+/// </summary>
+public static class OAuth1Helper
+{
+    private const string SignatureMethod = "HMAC-SHA1";
+    private const string OAuthVersion = "1.0";
+
+    /// <summary>
+    /// RFC 3986 percent-encoding: unreserved characters pass through, everything
+    /// else is upper-hex escaped.
+    /// </summary>
+    public static string PercentEncode(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var sb = new StringBuilder(bytes.Length * 3);
+        foreach (var b in bytes)
+        {
+            var c = (char)b;
+            if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9')
+                or '-' or '.' or '_' or '~')
+            {
+                sb.Append(c);
+            }
+            else
+            {
+                sb.Append('%');
+                sb.Append(b.ToString("X2", CultureInfo.InvariantCulture));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds the signature base string: METHOD&amp;encode(baseUrl)&amp;encode(sorted params).
+    /// </summary>
+    internal static string BuildSignatureBaseString(string httpMethod, string baseUrl,
+        IEnumerable<KeyValuePair<string, string>> parameters)
+    {
+        var normalized = string.Join("&", parameters
+            .Select(p => new KeyValuePair<string, string>(PercentEncode(p.Key), PercentEncode(p.Value)))
+            .OrderBy(p => p.Key, StringComparer.Ordinal)
+            .ThenBy(p => p.Value, StringComparer.Ordinal)
+            .Select(p => $"{p.Key}={p.Value}"));
+
+        return $"{httpMethod.ToUpperInvariant()}&{PercentEncode(baseUrl)}&{PercentEncode(normalized)}";
+    }
+
+    internal static string ComputeSignature(string baseString, string consumerSecret, string? tokenSecret)
+    {
+        var key = $"{PercentEncode(consumerSecret)}&{PercentEncode(tokenSecret ?? string.Empty)}";
+        using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(key));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
+        return Convert.ToBase64String(hash);
+    }
+
+    /// <summary>
+    /// Builds the full <c>Authorization: OAuth ...</c> header value for a request.
+    /// The nonce and timestamp are passed in so the result is deterministic and testable;
+    /// callers use <see cref="Sign"/> for the runtime path.
+    /// </summary>
+    internal static string BuildAuthorizationHeader(
+        string httpMethod,
+        string url,
+        string consumerKey,
+        string consumerSecret,
+        string? token,
+        string? tokenSecret,
+        string nonce,
+        long timestamp,
+        IEnumerable<KeyValuePair<string, string>>? requestParams = null,
+        string? callback = null,
+        string? verifier = null)
+    {
+        // Any query string on the url participates in the signature but not the header.
+        var baseUrl = url;
+        var collected = new List<KeyValuePair<string, string>>();
+        var qIndex = url.IndexOf('?');
+        if (qIndex >= 0)
+        {
+            baseUrl = url[..qIndex];
+            foreach (var pair in url[(qIndex + 1)..].Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kv = pair.Split('=', 2);
+                collected.Add(new KeyValuePair<string, string>(
+                    Uri.UnescapeDataString(kv[0]),
+                    kv.Length > 1 ? Uri.UnescapeDataString(kv[1]) : string.Empty));
+            }
+        }
+
+        if (requestParams != null) collected.AddRange(requestParams);
+
+        var oauthParams = new Dictionary<string, string>
+        {
+            ["oauth_consumer_key"] = consumerKey,
+            ["oauth_nonce"] = nonce,
+            ["oauth_signature_method"] = SignatureMethod,
+            ["oauth_timestamp"] = timestamp.ToString(CultureInfo.InvariantCulture),
+            ["oauth_version"] = OAuthVersion,
+        };
+        if (!string.IsNullOrEmpty(token)) oauthParams["oauth_token"] = token;
+        if (!string.IsNullOrEmpty(callback)) oauthParams["oauth_callback"] = callback;
+        if (!string.IsNullOrEmpty(verifier)) oauthParams["oauth_verifier"] = verifier;
+
+        var signatureParams = new List<KeyValuePair<string, string>>(collected);
+        signatureParams.AddRange(oauthParams);
+
+        var baseString = BuildSignatureBaseString(httpMethod, baseUrl, signatureParams);
+        oauthParams["oauth_signature"] = ComputeSignature(baseString, consumerSecret, tokenSecret);
+
+        // Only oauth_* params belong in the Authorization header.
+        var header = string.Join(", ", oauthParams
+            .OrderBy(p => p.Key, StringComparer.Ordinal)
+            .Select(p => $"{PercentEncode(p.Key)}=\"{PercentEncode(p.Value)}\""));
+
+        return "OAuth " + header;
+    }
+
+    /// <summary>
+    /// Runtime convenience: signs a request with a fresh nonce + current timestamp.
+    /// </summary>
+    public static string Sign(
+        string httpMethod,
+        string url,
+        string consumerKey,
+        string consumerSecret,
+        string? token,
+        string? tokenSecret,
+        IEnumerable<KeyValuePair<string, string>>? requestParams = null,
+        string? callback = null,
+        string? verifier = null)
+    {
+        var nonce = Guid.NewGuid().ToString("N");
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        return BuildAuthorizationHeader(httpMethod, url, consumerKey, consumerSecret, token, tokenSecret,
+            nonce, timestamp, requestParams, callback, verifier);
+    }
+}

--- a/src/HappyNotes.Services/SyncQueue/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HappyNotes.Services/SyncQueue/Extensions/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ public static class ServiceCollectionExtensions
         // Register handlers
         services.AddScoped<ISyncHandler, TelegramSyncHandler>();
         services.AddScoped<ISyncHandler, MastodonSyncHandler>();
+        services.AddScoped<ISyncHandler, FanfouSyncHandler>();
         services.AddScoped<ISyncHandler, ManticoreSearchSyncHandler>();
 
         // Register background processor

--- a/src/HappyNotes.Services/SyncQueue/Handlers/FanfouSyncHandler.cs
+++ b/src/HappyNotes.Services/SyncQueue/Handlers/FanfouSyncHandler.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+using Api.Framework.Helper;
+using Api.Framework.Models;
+using HappyNotes.Common;
+using HappyNotes.Entities;
+using HappyNotes.Repositories.interfaces;
+using HappyNotes.Services.interfaces;
+using HappyNotes.Services.SyncQueue.Configuration;
+using HappyNotes.Services.SyncQueue.Interfaces;
+using HappyNotes.Services.SyncQueue.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HappyNotes.Services.SyncQueue.Handlers;
+
+public class FanfouSyncHandler : ISyncHandler
+{
+    private readonly IFanfouService _fanfouService;
+    private readonly IFanfouUserAccountCacheService _fanfouUserAccountCacheService;
+    private readonly INoteRepository _noteRepository;
+    private readonly SyncQueueOptions _options;
+    private readonly JwtConfig _jwtConfig;
+    private readonly ILogger<FanfouSyncHandler> _logger;
+
+    public string ServiceName => Constants.FanfouService;
+
+    public int MaxRetryAttempts => _options.Handlers.TryGetValue(ServiceName, out var config)
+        ? config.MaxRetries
+        : 5;
+
+    public FanfouSyncHandler(
+        IFanfouService fanfouService,
+        IFanfouUserAccountCacheService fanfouUserAccountCacheService,
+        INoteRepository noteRepository,
+        IOptions<SyncQueueOptions> options,
+        IOptions<JwtConfig> jwtConfig,
+        ILogger<FanfouSyncHandler> logger)
+    {
+        _fanfouService = fanfouService;
+        _fanfouUserAccountCacheService = fanfouUserAccountCacheService;
+        _noteRepository = noteRepository;
+        _options = options.Value;
+        _jwtConfig = jwtConfig.Value;
+        _logger = logger;
+    }
+
+    public async Task<SyncResult> ProcessAsync(SyncTask task, CancellationToken cancellationToken)
+    {
+        try
+        {
+            FanfouSyncPayload? payload;
+
+            // Handle both typed and untyped task objects
+            if (task.Payload is JsonElement jsonElement)
+            {
+                payload = JsonSerializer.Deserialize<FanfouSyncPayload>(jsonElement.GetRawText(), JsonSerializerConfig.Default);
+            }
+            else if (task.Payload is FanfouSyncPayload fanfouPayload)
+            {
+                payload = fanfouPayload;
+            }
+            else
+            {
+                return SyncResult.Failure("Invalid payload type", shouldRetry: false);
+            }
+
+            if (payload == null)
+            {
+                return SyncResult.Failure("Failed to deserialize payload", shouldRetry: false);
+            }
+
+            // Security: Get access credentials from user account cache instead of payload
+            var userAccounts = await _fanfouUserAccountCacheService.GetAsync(task.UserId);
+            var userAccount = userAccounts.FirstOrDefault(a => a.Id == payload.UserAccountId);
+
+            if (userAccount == null)
+            {
+                return SyncResult.Failure($"No Fanfou user account found for user {task.UserId} and account {payload.UserAccountId}", shouldRetry: false);
+            }
+
+            var accessToken = userAccount.DecryptedAccessToken(_jwtConfig.SymmetricSecurityKey);
+            var accessTokenSecret = userAccount.DecryptedAccessTokenSecret(_jwtConfig.SymmetricSecurityKey);
+
+            return task.Action.ToUpper() switch
+            {
+                "CREATE" => await ProcessCreateAction(task, payload, accessToken, accessTokenSecret),
+                "UPDATE" => await ProcessUpdateAction(task, payload, accessToken, accessTokenSecret),
+                "DELETE" => await ProcessDeleteAction(task, payload, accessToken, accessTokenSecret),
+                _ => SyncResult.Failure($"Unknown action: {task.Action}", shouldRetry: false)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing Fanfou sync task {TaskId} for user {UserId}: {Error}",
+                task.Id, task.UserId, ex.Message);
+            return SyncResult.Failure(ex.Message);
+        }
+    }
+
+    private async Task<SyncResult> ProcessCreateAction(SyncTask task, FanfouSyncPayload payload, string accessToken, string accessTokenSecret)
+    {
+        try
+        {
+            _logger.LogDebug("Processing CREATE action for task {TaskId}", task.Id);
+
+            var statusId = await _fanfouService.SendStatusAsync(accessToken, accessTokenSecret, payload.FullContent, task.EntityId);
+
+            // Add the status ID to the note
+            await AddStatusIdToNote(task.EntityId, payload.UserAccountId, statusId);
+
+            _logger.LogDebug("Successfully created Fanfou status {StatusId} for task {TaskId}", statusId, task.Id);
+
+            return SyncResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create Fanfou status for task {TaskId}: {Error}", task.Id, ex.Message);
+            return SyncResult.Failure(ex.Message);
+        }
+    }
+
+    private async Task<SyncResult> ProcessUpdateAction(SyncTask task, FanfouSyncPayload payload, string accessToken, string accessTokenSecret)
+    {
+        try
+        {
+            // Fanfou has no edit API, so an update = destroy the old status + post a new one.
+            if (string.IsNullOrEmpty(payload.StatusId))
+            {
+                return SyncResult.Failure("StatusId is required for UPDATE action", shouldRetry: false);
+            }
+
+            _logger.LogDebug("Processing UPDATE action for task {TaskId}, replacing status {StatusId}", task.Id, payload.StatusId);
+
+            await _fanfouService.DeleteStatusAsync(accessToken, accessTokenSecret, payload.StatusId);
+            var newStatusId = await _fanfouService.SendStatusAsync(accessToken, accessTokenSecret, payload.FullContent, task.EntityId);
+
+            // Replace the old status id with the new one on the note.
+            await AddStatusIdToNote(task.EntityId, payload.UserAccountId, newStatusId);
+
+            _logger.LogDebug("Successfully replaced Fanfou status {OldStatusId} with {NewStatusId} for task {TaskId}",
+                payload.StatusId, newStatusId, task.Id);
+
+            return SyncResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update Fanfou status {StatusId} for task {TaskId}: {Error}",
+                payload.StatusId, task.Id, ex.Message);
+            return SyncResult.Failure(ex.Message);
+        }
+    }
+
+    private async Task<SyncResult> ProcessDeleteAction(SyncTask task, FanfouSyncPayload payload, string accessToken, string accessTokenSecret)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(payload.StatusId))
+            {
+                return SyncResult.Failure("StatusId is required for DELETE action", shouldRetry: false);
+            }
+
+            _logger.LogDebug("Processing DELETE action for task {TaskId}, status {StatusId}", task.Id, payload.StatusId);
+
+            await _fanfouService.DeleteStatusAsync(accessToken, accessTokenSecret, payload.StatusId);
+
+            // Remove the status ID from the note
+            await RemoveStatusIdFromNote(task.EntityId, payload.UserAccountId, payload.StatusId);
+
+            _logger.LogDebug("Successfully deleted Fanfou status {StatusId} for task {TaskId}", payload.StatusId, task.Id);
+
+            return SyncResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete Fanfou status {StatusId} for task {TaskId}: {Error}",
+                payload.StatusId, task.Id, ex.Message);
+            return SyncResult.Failure(ex.Message);
+        }
+    }
+
+    public TimeSpan CalculateRetryDelay(int attemptCount)
+    {
+        if (_options.Handlers.TryGetValue(ServiceName, out var config))
+        {
+            var delay = TimeSpan.FromSeconds(config.BaseDelaySeconds * Math.Pow(config.BackoffMultiplier, attemptCount - 1));
+            var maxDelay = TimeSpan.FromMinutes(config.MaxDelayMinutes);
+            return delay > maxDelay ? maxDelay : delay;
+        }
+
+        // Default fallback
+        return TimeSpan.FromMinutes(Math.Min(Math.Pow(2, attemptCount - 1), 30));
+    }
+
+    private async Task AddStatusIdToNote(long noteId, long userAccountId, string statusId)
+    {
+        var currentNote = await _noteRepository.GetFirstOrDefaultAsync(
+            n => n.Id == noteId,
+            orderBy: null);
+
+        if (currentNote == null)
+        {
+            _logger.LogWarning("Note {NoteId} not found, cannot add Fanfou status ID", noteId);
+            return;
+        }
+
+        currentNote.AddFanfouStatusId(userAccountId, statusId);
+
+        // Use precise update - only update FanfouStatusIds field
+        await _noteRepository.UpdateAsync(
+            note => new Note { FanfouStatusIds = currentNote.FanfouStatusIds },
+            note => note.Id == noteId);
+
+        _logger.LogDebug("Updated note {NoteId} FanfouStatusIds after adding {UserAccountId}:{StatusId}",
+            noteId, userAccountId, statusId);
+    }
+
+    private async Task RemoveStatusIdFromNote(long noteId, long userAccountId, string statusId)
+    {
+        var currentNote = await _noteRepository.GetFirstOrDefaultAsync(
+            n => n.Id == noteId,
+            orderBy: null);
+
+        if (currentNote == null || string.IsNullOrWhiteSpace(currentNote.FanfouStatusIds))
+        {
+            _logger.LogWarning("Note {NoteId} not found or has no Fanfou status IDs", noteId);
+            return;
+        }
+
+        currentNote.RemoveFanfouStatusId(userAccountId, statusId);
+
+        // Use precise update - only update FanfouStatusIds field
+        await _noteRepository.UpdateAsync(
+            note => new Note { FanfouStatusIds = currentNote.FanfouStatusIds },
+            note => note.Id == noteId);
+
+        _logger.LogDebug("Updated note {NoteId} FanfouStatusIds after removing {UserAccountId}:{StatusId}",
+            noteId, userAccountId, statusId);
+    }
+}

--- a/src/HappyNotes.Services/SyncQueue/Models/FanfouSyncPayload.cs
+++ b/src/HappyNotes.Services/SyncQueue/Models/FanfouSyncPayload.cs
@@ -1,0 +1,11 @@
+namespace HappyNotes.Services.SyncQueue.Models;
+
+public class FanfouSyncPayload
+{
+    public long UserAccountId { get; set; }
+    public string FullContent { get; set; } = string.Empty;
+    public string? StatusId { get; set; } // For DELETE operations
+    public bool IsPrivate { get; set; }
+    public bool IsMarkdown { get; set; }
+    public Dictionary<string, object> Metadata { get; set; } = new();
+}

--- a/src/HappyNotes.Services/interfaces/IFanfouService.cs
+++ b/src/HappyNotes.Services/interfaces/IFanfouService.cs
@@ -1,0 +1,31 @@
+using HappyNotes.Models;
+
+namespace HappyNotes.Services.interfaces;
+
+public interface IFanfouService
+{
+    /// <summary>
+    /// First OAuth leg: obtain temporary request credentials.
+    /// </summary>
+    Task<FanfouRequestToken> GetRequestTokenAsync();
+
+    /// <summary>
+    /// Build the URL the user is sent to in order to authorize the app.
+    /// </summary>
+    string GetAuthorizeUrl(string requestToken);
+
+    /// <summary>
+    /// Final OAuth leg: exchange the authorized request token + verifier for access credentials.
+    /// </summary>
+    Task<FanfouAccessToken> GetAccessTokenAsync(string requestToken, string requestTokenSecret, string verifier);
+
+    /// <summary>
+    /// Post a status to Fanfou. Returns the created status id.
+    /// </summary>
+    Task<string> SendStatusAsync(string accessToken, string accessTokenSecret, string content, long noteId = 0);
+
+    /// <summary>
+    /// Delete a status from Fanfou.
+    /// </summary>
+    Task DeleteStatusAsync(string accessToken, string accessTokenSecret, string statusId);
+}

--- a/src/HappyNotes.Services/interfaces/IFanfouUserAccountCacheService.cs
+++ b/src/HappyNotes.Services/interfaces/IFanfouUserAccountCacheService.cs
@@ -1,0 +1,10 @@
+using HappyNotes.Entities;
+
+namespace HappyNotes.Services.interfaces;
+
+public interface IFanfouUserAccountCacheService
+{
+    Task<IList<FanfouUserAccount>> GetAsync(long userId);
+    void Set(long userId, IList<FanfouUserAccount> account);
+    void ClearCache(long userId);
+}

--- a/tests/HappyNotes.Services.Tests/FanfouServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/FanfouServiceTests.cs
@@ -1,0 +1,47 @@
+using HappyNotes.Common;
+using HappyNotes.Services;
+
+namespace HappyNotes.Services.Tests;
+
+public class FanfouServiceTests
+{
+    [Test]
+    public void PrepareStatusText_ShortContent_ReturnedUnchanged()
+    {
+        const string content = "a short note";
+        var result = FanfouService.PrepareStatusText(content, noteId: 42);
+        Assert.That(result, Is.EqualTo(content));
+    }
+
+    [Test]
+    public void PrepareStatusText_AtLimit_ReturnedUnchanged()
+    {
+        var content = new string('x', Constants.FanfouStatusLength);
+        var result = FanfouService.PrepareStatusText(content, noteId: 42);
+        Assert.That(result, Is.EqualTo(content));
+        Assert.That(result.Length, Is.EqualTo(Constants.FanfouStatusLength));
+    }
+
+    [Test]
+    public void PrepareStatusText_LongContentWithNoteId_TruncatesWithLinkWithinBudget()
+    {
+        var content = new string('x', 500);
+        var result = FanfouService.PrepareStatusText(content, noteId: 42);
+
+        Assert.That(result.Length, Is.LessThanOrEqualTo(Constants.FanfouStatusLength),
+            "status must never exceed Fanfou's 140-char limit");
+        Assert.That(result, Does.Contain($"{Constants.HappyNotesWebsite}/note/42"),
+            "over-length notes keep a permalink back to the note");
+        Assert.That(result, Does.Contain("…"));
+    }
+
+    [Test]
+    public void PrepareStatusText_LongContentWithoutNoteId_HardTruncates()
+    {
+        var content = new string('x', 500);
+        var result = FanfouService.PrepareStatusText(content, noteId: 0);
+
+        Assert.That(result.Length, Is.EqualTo(Constants.FanfouStatusLength));
+        Assert.That(result, Does.Not.Contain("/note/"));
+    }
+}

--- a/tests/HappyNotes.Services.Tests/FanfouSyncHandlerTests.cs
+++ b/tests/HappyNotes.Services.Tests/FanfouSyncHandlerTests.cs
@@ -1,0 +1,284 @@
+using System.Text.Json;
+using Api.Framework.Helper;
+using Api.Framework.Models;
+using HappyNotes.Common;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Repositories.interfaces;
+using HappyNotes.Services.interfaces;
+using HappyNotes.Services.SyncQueue.Configuration;
+using HappyNotes.Services.SyncQueue.Handlers;
+using HappyNotes.Services.SyncQueue.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace HappyNotes.Services.Tests;
+
+public class FanfouSyncHandlerTests
+{
+    private Mock<IFanfouService> _mockFanfouService;
+    private Mock<IFanfouUserAccountCacheService> _mockFanfouUserAccountCacheService;
+    private Mock<INoteRepository> _mockNoteRepository;
+    private Mock<IOptions<SyncQueueOptions>> _mockSyncQueueOptions;
+    private Mock<IOptions<JwtConfig>> _mockJwtConfig;
+    private Mock<ILogger<FanfouSyncHandler>> _mockLogger;
+    private FanfouSyncHandler _handler;
+
+    private const string TestJwtKey = "test_key_1234567890123456";
+    private const string PlainAccessToken = "plain-access-token";
+    private const string PlainAccessTokenSecret = "plain-access-secret";
+    private const long TestUserId = 1;
+    private const long TestUserAccountId = 10;
+    private const long TestNoteId = 123;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockFanfouService = new Mock<IFanfouService>();
+        _mockFanfouUserAccountCacheService = new Mock<IFanfouUserAccountCacheService>();
+        _mockNoteRepository = new Mock<INoteRepository>();
+        _mockSyncQueueOptions = new Mock<IOptions<SyncQueueOptions>>();
+        _mockJwtConfig = new Mock<IOptions<JwtConfig>>();
+        _mockLogger = new Mock<ILogger<FanfouSyncHandler>>();
+
+        _mockSyncQueueOptions.Setup(x => x.Value).Returns(new SyncQueueOptions());
+        _mockJwtConfig.Setup(x => x.Value).Returns(new JwtConfig { SymmetricSecurityKey = TestJwtKey });
+
+        _handler = new FanfouSyncHandler(
+            _mockFanfouService.Object,
+            _mockFanfouUserAccountCacheService.Object,
+            _mockNoteRepository.Object,
+            _mockSyncQueueOptions.Object,
+            _mockJwtConfig.Object,
+            _mockLogger.Object);
+    }
+
+    private static SyncTask CreateTask(string action, FanfouSyncPayload payload, long entityId = TestNoteId, long userId = TestUserId)
+    {
+        var task = SyncTask.Create(Constants.FanfouService, action, entityId, userId, payload);
+        return new SyncTask
+        {
+            Id = task.Id,
+            Service = task.Service,
+            Action = task.Action,
+            EntityId = task.EntityId,
+            UserId = task.UserId,
+            Payload = task.Payload,
+            AttemptCount = task.AttemptCount,
+            CreatedAt = task.CreatedAt,
+            ScheduledFor = task.ScheduledFor,
+            Metadata = task.Metadata
+        };
+    }
+
+    private void SetupUserAccount()
+    {
+        var accounts = new List<FanfouUserAccount>
+        {
+            new()
+            {
+                Id = TestUserAccountId,
+                UserId = TestUserId,
+                Status = FanfouUserAccountStatus.Normal,
+                AccessToken = TextEncryptionHelper.Encrypt(PlainAccessToken, TestJwtKey),
+                AccessTokenSecret = TextEncryptionHelper.Encrypt(PlainAccessTokenSecret, TestJwtKey),
+            }
+        };
+
+        _mockFanfouUserAccountCacheService.Setup(s => s.GetAsync(TestUserId)).ReturnsAsync(accounts);
+    }
+
+    [Test]
+    public async Task ProcessAsync_InvalidPayloadType_ReturnsFailure()
+    {
+        var task = new SyncTask { Service = Constants.FanfouService, Action = "CREATE", EntityId = TestNoteId, UserId = TestUserId, Payload = "invalid" };
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ErrorMessage, Is.EqualTo("Invalid payload type"));
+        Assert.That(result.ShouldRetry, Is.False);
+    }
+
+    [Test]
+    public async Task ProcessAsync_NoMatchingUserAccount_ReturnsFailure()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = 999, FullContent = "hi" };
+        var task = CreateTask("CREATE", payload);
+        SetupUserAccount();
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ErrorMessage, Is.EqualTo($"No Fanfou user account found for user {TestUserId} and account 999"));
+        Assert.That(result.ShouldRetry, Is.False);
+    }
+
+    [Test]
+    public async Task ProcessAsync_UnknownAction_ReturnsFailure()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, FullContent = "hi" };
+        var task = CreateTask("WHAT", payload);
+        SetupUserAccount();
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ErrorMessage, Is.EqualTo("Unknown action: WHAT"));
+        Assert.That(result.ShouldRetry, Is.False);
+    }
+
+    [Test]
+    public async Task ProcessCreateAction_HappyPath_SendsStatusAndUpdatesNote()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, FullContent = "Test content" };
+        var task = CreateTask("CREATE", payload);
+
+        SetupUserAccount();
+        _mockFanfouService
+            .Setup(s => s.SendStatusAsync(PlainAccessToken, PlainAccessTokenSecret, payload.FullContent, TestNoteId))
+            .ReturnsAsync("status-100");
+        _mockNoteRepository
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>(), null))
+            .ReturnsAsync(new Note { Id = TestNoteId, FanfouStatusIds = null });
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.True);
+        _mockFanfouService.Verify(s => s.SendStatusAsync(PlainAccessToken, PlainAccessTokenSecret, payload.FullContent, TestNoteId), Times.Once);
+        _mockNoteRepository.Verify(r => r.UpdateAsync(
+            It.Is<System.Linq.Expressions.Expression<Func<Note, Note>>>(expr =>
+                expr.Compile()(new Note()).FanfouStatusIds == $"{TestUserAccountId}:status-100"),
+            It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>()
+        ), Times.Once);
+    }
+
+    [Test]
+    public async Task ProcessCreateAction_SendThrows_ReturnsFailureWithRetry()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, FullContent = "Test content" };
+        var task = CreateTask("CREATE", payload);
+
+        SetupUserAccount();
+        _mockFanfouService
+            .Setup(s => s.SendStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>()))
+            .ThrowsAsync(new Exception("Fanfou unreachable"));
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ErrorMessage, Is.EqualTo("Fanfou unreachable"));
+        Assert.That(result.ShouldRetry, Is.True);
+    }
+
+    [Test]
+    public async Task ProcessUpdateAction_EmptyStatusId_ReturnsFailure()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, FullContent = "Updated", StatusId = null };
+        var task = CreateTask("UPDATE", payload);
+        SetupUserAccount();
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ErrorMessage, Is.EqualTo("StatusId is required for UPDATE action"));
+        Assert.That(result.ShouldRetry, Is.False);
+    }
+
+    [Test]
+    public async Task ProcessUpdateAction_HappyPath_DeletesOldPostsNewAndUpdatesNote()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, FullContent = "Updated content", StatusId = "status-old" };
+        var task = CreateTask("UPDATE", payload);
+
+        SetupUserAccount();
+        _mockFanfouService.Setup(s => s.DeleteStatusAsync(PlainAccessToken, PlainAccessTokenSecret, "status-old")).Returns(Task.CompletedTask);
+        _mockFanfouService.Setup(s => s.SendStatusAsync(PlainAccessToken, PlainAccessTokenSecret, payload.FullContent, TestNoteId)).ReturnsAsync("status-new");
+        _mockNoteRepository
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>(), null))
+            .ReturnsAsync(new Note { Id = TestNoteId, FanfouStatusIds = $"{TestUserAccountId}:status-old" });
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.True);
+        _mockFanfouService.Verify(s => s.DeleteStatusAsync(PlainAccessToken, PlainAccessTokenSecret, "status-old"), Times.Once);
+        _mockFanfouService.Verify(s => s.SendStatusAsync(PlainAccessToken, PlainAccessTokenSecret, payload.FullContent, TestNoteId), Times.Once);
+        _mockNoteRepository.Verify(r => r.UpdateAsync(
+            It.Is<System.Linq.Expressions.Expression<Func<Note, Note>>>(expr =>
+                expr.Compile()(new Note()).FanfouStatusIds == $"{TestUserAccountId}:status-new"),
+            It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>()
+        ), Times.Once);
+    }
+
+    [Test]
+    public async Task ProcessDeleteAction_EmptyStatusId_ReturnsFailure()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, StatusId = null };
+        var task = CreateTask("DELETE", payload);
+        SetupUserAccount();
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.ErrorMessage, Is.EqualTo("StatusId is required for DELETE action"));
+        Assert.That(result.ShouldRetry, Is.False);
+    }
+
+    [Test]
+    public async Task ProcessDeleteAction_HappyPath_DeletesStatusAndUpdatesNote()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, StatusId = "status-100" };
+        var task = CreateTask("DELETE", payload);
+
+        SetupUserAccount();
+        _mockFanfouService.Setup(s => s.DeleteStatusAsync(PlainAccessToken, PlainAccessTokenSecret, "status-100")).Returns(Task.CompletedTask);
+        _mockNoteRepository
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>(), null))
+            .ReturnsAsync(new Note { Id = TestNoteId, FanfouStatusIds = $"{TestUserAccountId}:status-100,99:status-999" });
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.True);
+        _mockFanfouService.Verify(s => s.DeleteStatusAsync(PlainAccessToken, PlainAccessTokenSecret, "status-100"), Times.Once);
+        _mockNoteRepository.Verify(r => r.UpdateAsync(
+            It.Is<System.Linq.Expressions.Expression<Func<Note, Note>>>(expr =>
+                expr.Compile()(new Note()).FanfouStatusIds == "99:status-999"),
+            It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>()
+        ), Times.Once);
+    }
+
+    [Test]
+    public async Task ProcessAsync_JsonElementPayload_HandlesCorrectly()
+    {
+        var payload = new FanfouSyncPayload { UserAccountId = TestUserAccountId, FullContent = "Test content" };
+        var jsonPayload = JsonSerializer.SerializeToElement(payload);
+        var task = new SyncTask { EntityId = TestNoteId, UserId = TestUserId, Service = Constants.FanfouService, Action = "CREATE", Payload = jsonPayload };
+
+        SetupUserAccount();
+        _mockFanfouService
+            .Setup(s => s.SendStatusAsync(PlainAccessToken, PlainAccessTokenSecret, payload.FullContent, TestNoteId))
+            .ReturnsAsync("status-200");
+        _mockNoteRepository
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<Note, bool>>>(), null))
+            .ReturnsAsync(new Note { Id = TestNoteId, FanfouStatusIds = null });
+
+        var result = await _handler.ProcessAsync(task, CancellationToken.None);
+
+        Assert.That(result.IsSuccess, Is.True);
+        _mockFanfouService.Verify(s => s.SendStatusAsync(PlainAccessToken, PlainAccessTokenSecret, payload.FullContent, TestNoteId), Times.Once);
+    }
+
+    [Test]
+    public void ServiceName_ReturnsCorrectValue()
+    {
+        Assert.That(_handler.ServiceName, Is.EqualTo(Constants.FanfouService));
+    }
+
+    [Test]
+    public void CalculateRetryDelay_UsesDefaultExponentialBackoff()
+    {
+        Assert.That(_handler.CalculateRetryDelay(1), Is.EqualTo(TimeSpan.FromMinutes(1)));
+        Assert.That(_handler.CalculateRetryDelay(2), Is.EqualTo(TimeSpan.FromMinutes(2)));
+        Assert.That(_handler.CalculateRetryDelay(3), Is.EqualTo(TimeSpan.FromMinutes(4)));
+    }
+}

--- a/tests/HappyNotes.Services.Tests/FanfouSyncNoteServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/FanfouSyncNoteServiceTests.cs
@@ -1,0 +1,122 @@
+using HappyNotes.Common;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Services.interfaces;
+using HappyNotes.Services.SyncQueue.Interfaces;
+using HappyNotes.Services.SyncQueue.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace HappyNotes.Services.Tests;
+
+public class FanfouSyncNoteServiceTests
+{
+    private Mock<IFanfouUserAccountCacheService> _mockCacheService;
+    private Mock<ISyncQueueService> _mockSyncQueueService;
+    private Mock<ILogger<FanfouSyncNoteService>> _mockLogger;
+    private FanfouSyncNoteService _service;
+
+    private const long TestUserId = 1;
+    private const long TestUserAccountId = 10;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockCacheService = new Mock<IFanfouUserAccountCacheService>();
+        _mockSyncQueueService = new Mock<ISyncQueueService>();
+        _mockLogger = new Mock<ILogger<FanfouSyncNoteService>>();
+
+        _service = new FanfouSyncNoteService(
+            _mockCacheService.Object,
+            _mockSyncQueueService.Object,
+            _mockLogger.Object);
+    }
+
+    [TestCase(true, FanfouSyncType.All, "", true)]
+    [TestCase(false, FanfouSyncType.All, "", true)]
+    [TestCase(false, FanfouSyncType.PublicOnly, "", true)]
+    [TestCase(true, FanfouSyncType.PublicOnly, "", false)]
+    [TestCase(true, FanfouSyncType.TagFanfouOnly, "fanfou", true)]
+    [TestCase(false, FanfouSyncType.TagFanfouOnly, "fanfou", true)]
+    [TestCase(false, FanfouSyncType.TagFanfouOnly, "", false)]
+    [TestCase(true, FanfouSyncType.TagFanfouOnly, "", false)]
+    public async Task SyncNewNote_RespectsSyncRule(bool isPrivate, FanfouSyncType syncType, string tag, bool shouldSync)
+    {
+        // Arrange
+        var account = new FanfouUserAccount
+        {
+            Id = TestUserAccountId,
+            UserId = TestUserId,
+            Status = FanfouUserAccountStatus.Normal,
+            SyncType = syncType,
+        };
+        _mockCacheService.Setup(s => s.GetAsync(TestUserId)).ReturnsAsync(new List<FanfouUserAccount> { account });
+
+        var note = new Note
+        {
+            Id = 123,
+            UserId = TestUserId,
+            IsPrivate = isPrivate,
+            TagList = string.IsNullOrEmpty(tag) ? new List<string>() : new List<string> { tag },
+        };
+
+        // Act
+        await _service.SyncNewNote(note, "test content");
+
+        // Assert
+        _mockSyncQueueService.Verify(
+            s => s.EnqueueAsync(Constants.FanfouService, It.IsAny<SyncTask<FanfouSyncPayload>>()),
+            shouldSync ? Times.Once() : Times.Never());
+    }
+
+    [Test]
+    public async Task SyncNewNote_NoAccounts_DoesNotEnqueue()
+    {
+        _mockCacheService.Setup(s => s.GetAsync(TestUserId)).ReturnsAsync(new List<FanfouUserAccount>());
+
+        var note = new Note { Id = 123, UserId = TestUserId, IsPrivate = false };
+        await _service.SyncNewNote(note, "test content");
+
+        _mockSyncQueueService.Verify(
+            s => s.EnqueueAsync(It.IsAny<string>(), It.IsAny<SyncTask<FanfouSyncPayload>>()),
+            Times.Never());
+    }
+
+    [Test]
+    public async Task SyncDeleteNote_WithSyncedStatus_EnqueuesDelete()
+    {
+        var account = new FanfouUserAccount
+        {
+            Id = TestUserAccountId,
+            UserId = TestUserId,
+            Status = FanfouUserAccountStatus.Normal,
+            SyncType = FanfouSyncType.All,
+        };
+        _mockCacheService.Setup(s => s.GetAsync(TestUserId)).ReturnsAsync(new List<FanfouUserAccount> { account });
+
+        var note = new Note
+        {
+            Id = 123,
+            UserId = TestUserId,
+            FanfouStatusIds = $"{TestUserAccountId}:status-100",
+        };
+
+        await _service.SyncDeleteNote(note);
+
+        _mockSyncQueueService.Verify(
+            s => s.EnqueueAsync(Constants.FanfouService,
+                It.Is<SyncTask<FanfouSyncPayload>>(t => t.Action == "DELETE" && t.Payload.StatusId == "status-100")),
+            Times.Once());
+    }
+
+    [Test]
+    public async Task SyncDeleteNote_NoSyncData_DoesNotEnqueue()
+    {
+        var note = new Note { Id = 123, UserId = TestUserId, FanfouStatusIds = null };
+        await _service.SyncDeleteNote(note);
+
+        _mockSyncQueueService.Verify(
+            s => s.EnqueueAsync(It.IsAny<string>(), It.IsAny<SyncTask<FanfouSyncPayload>>()),
+            Times.Never());
+    }
+}

--- a/tests/HappyNotes.Services.Tests/NoteTagServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/NoteTagServiceTests.cs
@@ -125,6 +125,7 @@ public class NoteTagServiceGetTagDataTests
                 Tags TEXT NOT NULL,
                 TelegramMessageIds TEXT,
                 MastodonTootIds TEXT,
+                FanfouStatusIds TEXT,
                 CreatedAt INTEGER NOT NULL,
                 UpdatedAt INTEGER,
                 DeletedAt INTEGER

--- a/tests/HappyNotes.Services.Tests/OAuth1HelperTests.cs
+++ b/tests/HappyNotes.Services.Tests/OAuth1HelperTests.cs
@@ -1,0 +1,98 @@
+using HappyNotes.Services;
+
+namespace HappyNotes.Services.Tests;
+
+public class OAuth1HelperTests
+{
+    [TestCase("abcXYZ123-._~", "abcXYZ123-._~")] // unreserved chars pass through
+    [TestCase(" ", "%20")]
+    [TestCase("=", "%3D")]
+    [TestCase("&", "%26")]
+    [TestCase("@", "%40")]
+    [TestCase("+", "%2B")]
+    [TestCase("r b", "r%20b")]
+    public void PercentEncode_MatchesRfc3986(string input, string expected)
+    {
+        Assert.That(OAuth1Helper.PercentEncode(input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void PercentEncode_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.That(OAuth1Helper.PercentEncode(null), Is.EqualTo(string.Empty));
+        Assert.That(OAuth1Helper.PercentEncode(string.Empty), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void BuildSignatureBaseString_MatchesRfc5849Example()
+    {
+        // The canonical example from RFC 5849 section 3.4.1.1 (no oauth_version).
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("b5", "=%3D"),
+            new("a3", "a"),
+            new("c@", ""),
+            new("a2", "r b"),
+            new("c2", ""),
+            new("a3", "2 q"),
+            new("oauth_consumer_key", "9djdj82h48djs9d2"),
+            new("oauth_token", "kkk9d7dh3k39sjv7"),
+            new("oauth_signature_method", "HMAC-SHA1"),
+            new("oauth_timestamp", "137131201"),
+            new("oauth_nonce", "7d8f3e4a"),
+        };
+
+        var baseString = OAuth1Helper.BuildSignatureBaseString("POST", "http://example.com/request", parameters);
+
+        const string expected =
+            "POST&http%3A%2F%2Fexample.com%2Frequest&a2%3Dr%2520b%26a3%3D2%2520q%26a3%3Da" +
+            "%26b5%3D%253D%25253D%26c%2540%3D%26c2%3D%26oauth_consumer_key%3D9djdj82h48djs9d2" +
+            "%26oauth_nonce%3D7d8f3e4a%26oauth_signature_method%3DHMAC-SHA1" +
+            "%26oauth_timestamp%3D137131201%26oauth_token%3Dkkk9d7dh3k39sjv7";
+
+        Assert.That(baseString, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ComputeSignature_IsDeterministicAndCorrectLength()
+    {
+        const string baseString = "POST&http%3A%2F%2Fexample.com%2Frequest&status%3Dhello";
+        var sig1 = OAuth1Helper.ComputeSignature(baseString, "consumer-secret", "token-secret");
+        var sig2 = OAuth1Helper.ComputeSignature(baseString, "consumer-secret", "token-secret");
+
+        Assert.That(sig1, Is.EqualTo(sig2)); // deterministic
+        Assert.That(sig1, Is.Not.Empty);
+        // HMAC-SHA1 => 20 bytes => 28 base64 chars (with padding)
+        Assert.That(sig1.Length, Is.EqualTo(28));
+    }
+
+    [Test]
+    public void ComputeSignature_DifferentTokenSecret_ProducesDifferentSignature()
+    {
+        const string baseString = "POST&http%3A%2F%2Fexample.com%2Frequest&status%3Dhello";
+        var sig1 = OAuth1Helper.ComputeSignature(baseString, "consumer-secret", "token-secret-a");
+        var sig2 = OAuth1Helper.ComputeSignature(baseString, "consumer-secret", "token-secret-b");
+
+        Assert.That(sig1, Is.Not.EqualTo(sig2));
+    }
+
+    [Test]
+    public void BuildAuthorizationHeader_ContainsRequiredOAuthFields()
+    {
+        var header = OAuth1Helper.BuildAuthorizationHeader(
+            "POST", "https://api.fanfou.com/statuses/update.json",
+            "consumer-key", "consumer-secret",
+            token: "access-token", tokenSecret: "access-secret",
+            nonce: "abc123", timestamp: 1234567890,
+            requestParams: new Dictionary<string, string> { ["status"] = "hi" });
+
+        Assert.That(header, Does.StartWith("OAuth "));
+        Assert.That(header, Does.Contain("oauth_consumer_key=\"consumer-key\""));
+        Assert.That(header, Does.Contain("oauth_token=\"access-token\""));
+        Assert.That(header, Does.Contain("oauth_signature_method=\"HMAC-SHA1\""));
+        Assert.That(header, Does.Contain("oauth_nonce=\"abc123\""));
+        Assert.That(header, Does.Contain("oauth_timestamp=\"1234567890\""));
+        Assert.That(header, Does.Contain("oauth_version=\"1.0\""));
+        Assert.That(header, Does.Contain("oauth_signature=\""));
+    }
+}


### PR DESCRIPTION
Closes #12

Adds **Fanfou (饭否)** as a third auto-sync target alongside Telegram and Mastodon, plugged into the existing Redis SyncQueue (same retry/failure semantics, no new queue infra).

## Design
Fanfou differs from Mastodon in two structural ways that shape the code:
- **Single service** (`api.fanfou.com`) → app consumer key/secret live in the `Fanfou` **config** section (placeholders, injected at deploy), not a per-instance DB table. One `FanfouUserAccount` per user.
- **OAuth 1.0a** (three-legged) → `OAuth1Helper`, a minimal RFC 5849 HMAC-SHA1 signer (verified in tests against the RFC 5849 base-string example). No maintained .NET SDK.
- **No edit API** → an UPDATE = destroy the old status + post a new one.
- **140-char limit** → over-length notes truncate with a permalink back to the note, reserved inside the 140-char budget.

## What's included
- `OAuth1Helper`, `FanfouService` (request_token / access_token / statuses.update / statuses.destroy)
- `FanfouSyncNoteService` (enqueue + sync rule: All / PublicOnly / `#fanfou` tag) + `FanfouSyncHandler`
- `FanfouAuthController` (OAuth) + `FanfouUserAccountController` (settings) — request-token→user binding is single-use + short-TTL so a leaked `oauth_token` can't rebind an account
- `FanfouUserAccount` entity/table + `Note.FanfouStatusIds` column (migration)
- DI wiring, `appsettings.json` `Fanfou` block, `CLAUDE.md` Supported Services
- Unit tests: OAuth1 signer (incl. RFC vector), truncation, handler CRUD, sync-rule branching. Full unit suite green (299 tests).

## Notes for review
- **Live end-to-end is not exercised** — needs the real Fanfou consumer key/secret (held by shukebeta). Logic is unit-tested; posting a real status is pending credentials at deploy.
- **Fanfou has no per-status visibility** — under the `All` rule a private note posts publicly to Fanfou (Fanfou can't mark it private). This is intentional Mastodon-parity for the tri-state, but users who don't want private notes public should pick `PublicOnly`.
- The note permalink used on truncation is `{HappyNotesWebsite}/note/{id}` — confirm it matches the frontend route (SHUKE-LABS/HappyNotes#52).
- `documents/database/all-db-definition.sql` is empty/unmaintained, so only the changelist migration was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)