### PR TITLE
feat: semantic (vector) note search merged into keyword search (#53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The application uses a **Redis-based queue system** for reliable background sync
 - ✅ **Telegram**: Full queue integration with channel management
 - ✅ **Mastodon**: Complete queue integration with instance management
 - ✅ **Fanfou**: Queue integration via OAuth 1.0a; per-user sync rule (all / public-only / `#fanfou` tag)
-- ⏳ **ManticoreSearch**: Not yet migrated (still uses direct sync)
+- ✅ **ManticoreSearch**: SyncQueue-integrated (`ManticoreSyncNoteService` enqueuer + `ManticoreSearchSyncHandler` consumer). Indexes keyword content **and**, when semantic search is enabled, the note's embedding vector — both written in one REPLACE per note.
 
 ### Configuration
 - **Redis Connection**: Set `REDIS_CONNECTION_STRING` environment variable
@@ -83,3 +83,16 @@ The application uses a **Redis-based queue system** for reliable background sync
 - **Task Recovery**: Automatic recovery of expired/failed tasks
 - **Service Isolation**: Per-service queues prevent cross-contamination
 - **Graceful Degradation**: Queue failures don't crash the main application
+
+## Search (keyword + semantic)
+
+Note search runs over the Manticore `noteindex` table.
+
+- **Keyword** (always on): Manticore full-text, bigram-tokenized for CJK. Built by `SearchService._BuildNoteSearchQuery` and paged directly by Manticore.
+- **Semantic (vector)** (opt-in via `SemanticSearch:Enabled`): a `float_vector` KNN attribute (HNSW, cosine) on the **same** `noteindex`. Query-time flow: embed the query, run a Manticore KNN search (`GetSemanticNoteIdsAsync`), then merge into the keyword results — keyword hits first, then deduped semantic candidates by similarity — and page over the merged list. Transparent to clients: same `/notes/search` response shape.
+- **Embeddings — self-hosted by default** (privacy): generated via a self-hosted endpoint (Ollama `bge-m3`, 1024-dim, cosine) by `EmbeddingService`. Note text never leaves our infrastructure and there is no per-token cost. Switching to a hosted embedding API is a config-only change (re-embed required). Vectors are generated in the SyncQueue handler (background), never in the HTTP request path.
+- **Isolation**: the KNN query applies the **same** owner (`UserId`) + delete-state (`DeletedAt`) filters as the keyword path (`_BuildOwnerFilterClauses`), so vector search never leaks another user's or a soft-deleted note; a user's own private notes stay findable (parity with keyword search).
+- **Graceful fallback**: if embeddings or KNN are unavailable, search degrades to keyword-only with no error.
+- **Write-path note**: Manticore requires REPLACE (not UPDATE) to change a full-text field or a `float_vector`, so a single writer rewrites content + vector together to avoid clobbering the vector. Deletes/undeletes stay numeric `deletedat` updates.
+- **Config**: `SemanticSearch` section in `appsettings.json` (`EmbeddingEndpoint`, `EmbeddingModel`, `Dimensions`, `Similarity`, `TopK`, `MaxDistance`, `KeywordMergeCap`, `EmbeddingTimeoutSeconds`, backfill options). The `noteindex` schema (incl. `Embedding float_vector`) lives in `docker/create_table.sql`; adding the column requires table recreation + reindex.
+- **Backfill**: existing notes are embedded by the resumable, batched `NoteVectorBackfillService`, triggered off-peak via `POST /api/admin/vector-backfill/run` (Admin policy). Progress is cursor-persisted, so a stopped run resumes.

--- a/docker/create_table.sql
+++ b/docker/create_table.sql
@@ -1,5 +1,10 @@
 DROP TABLE IF EXISTS NoteIndex;
 
+-- The Embedding float_vector adds semantic (KNN) search to the same index used for keyword search.
+-- knn_dims must equal SemanticSearch:Dimensions (bge-m3 = 1024); hnsw_similarity must equal
+-- SemanticSearch:Similarity (cosine). float_vector + KNN require a real-time table (Manticore >= 6.2).
+-- Adding/removing this column requires recreating the table and a full reindex (see docker/manticore-init
+-- and the resumable vector backfill job / api/admin/vector-backfill endpoint).
 CREATE TABLE NoteIndex (
     Id BIGINT,
     UserId BIGINT,
@@ -10,7 +15,8 @@ CREATE TABLE NoteIndex (
     UpdatedAt BIGINT,
     DeletedAt BIGINT,
     Content TEXT,
-    Tags TEXT
+    Tags TEXT,
+    Embedding float_vector knn_type='hnsw' knn_dims='1024' hnsw_similarity='cosine'
 )
 ngram_len='2'
 ngram_chars='U+3400..U+4DBF,U+4E00..U+9FFF,U+F900..U+FAFF'

--- a/src/HappyNotes.Api/Controllers/VectorBackfillAdminController.cs
+++ b/src/HappyNotes.Api/Controllers/VectorBackfillAdminController.cs
@@ -1,0 +1,50 @@
+using HappyNotes.Services.interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace HappyNotes.Api.Controllers;
+
+/// <summary>
+/// Admin-only trigger for the resumable semantic-search vector backfill. Run off-peak; safe to rerun —
+/// a completed run is a no-op and an interrupted run resumes from its cursor.
+/// </summary>
+[ApiController]
+[Route("api/admin/vector-backfill")]
+[Authorize(Policy = "Admin")]
+public class VectorBackfillAdminController : ControllerBase
+{
+    private readonly INoteVectorBackfillService _backfillService;
+    private readonly ILogger<VectorBackfillAdminController> _logger;
+
+    public VectorBackfillAdminController(
+        INoteVectorBackfillService backfillService,
+        ILogger<VectorBackfillAdminController> logger)
+    {
+        _backfillService = backfillService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Runs the backfill to completion (or until the embedding backend becomes unavailable, in which case
+    /// it stops and can be rerun to resume). Optional batchSize overrides the configured default.
+    /// </summary>
+    [HttpPost("run")]
+    public async Task<ActionResult<VectorBackfillResult>> Run(int? batchSize = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _backfillService.RunAsync(batchSize, cancellationToken);
+            return Ok(result);
+        }
+        catch (OperationCanceledException)
+        {
+            return StatusCode(499, "Backfill cancelled by client");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Vector backfill failed");
+            return StatusCode(500, "Internal server error");
+        }
+    }
+}

--- a/src/HappyNotes.Api/Program.cs
+++ b/src/HappyNotes.Api/Program.cs
@@ -64,6 +64,9 @@ if (manticoreOptions != null)
     builder.Services.AddSingleton(manticoreOptions);
 }
 
+var semanticSearchOptions = builder.Configuration.GetSection("SemanticSearch").Get<SemanticSearchOptions>() ?? new SemanticSearchOptions();
+builder.Services.AddSingleton(semanticSearchOptions);
+
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
 builder.Services.AddCors(SetupCors(builder));

--- a/src/HappyNotes.Api/ServiceExtensions.cs
+++ b/src/HappyNotes.Api/ServiceExtensions.cs
@@ -31,6 +31,8 @@ public static class ServiceExtensions
         services.AddScoped<ISyncNoteService, TelegramSyncNoteService>();
         services.AddScoped<ISyncNoteService, ManticoreSyncNoteService>();
         services.AddScoped<ISearchService, SearchService>();
+        services.AddScoped<IEmbeddingService, EmbeddingService>();
+        services.AddScoped<INoteVectorBackfillService, NoteVectorBackfillService>();
         services.AddScoped<IDatabaseClient, DatabaseClient>();
     }
 }

--- a/src/HappyNotes.Api/appsettings.json
+++ b/src/HappyNotes.Api/appsettings.json
@@ -36,6 +36,19 @@
     "HttpEndpoint": "http://default_manticore_server:9312/",
     "ApplicationName": "ManticoreSearch"
   },
+  "SemanticSearch": {
+    "Enabled": false,
+    "EmbeddingEndpoint": "embedding-endpoint-placeholder",
+    "EmbeddingModel": "bge-m3",
+    "Dimensions": 1024,
+    "Similarity": "cosine",
+    "TopK": 50,
+    "MaxDistance": 0,
+    "KeywordMergeCap": 1000,
+    "EmbeddingTimeoutSeconds": 30,
+    "BackfillBatchSize": 100,
+    "BackfillCursorPath": "vector-backfill.cursor"
+  },
   "SeqServerUrl": "https://seq.dev.shukebeta.com",
   "SeqApiKey": "seq-api-key-placeholder",
   "Version": "VERSION_PLACEHOLDER",

--- a/src/HappyNotes.Models/Search/ManticoreHit.cs
+++ b/src/HappyNotes.Models/Search/ManticoreHit.cs
@@ -4,5 +4,9 @@ public class ManticoreHit
 {
     public long _id { get; set; }
     public long _score { get; set; }
+
+    /// <summary>Distance to the query vector for KNN searches (lower = closer). Absent/0 for keyword searches.</summary>
+    public double _knn_dist { get; set; }
+
     public required ManticoreSource _source { get; set; }
 }

--- a/src/HappyNotes.Services/EmbeddingService.cs
+++ b/src/HappyNotes.Services/EmbeddingService.cs
@@ -1,0 +1,89 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HappyNotes.Common;
+using HappyNotes.Services.interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace HappyNotes.Services;
+
+/// <summary>
+/// Generates embeddings via a self-hosted HTTP endpoint (default: Ollama). Every failure path returns
+/// null rather than throwing, so a down/slow backend degrades search to keyword-only instead of erroring.
+/// </summary>
+public class EmbeddingService : IEmbeddingService
+{
+    private readonly HttpClient _httpClient;
+    private readonly SemanticSearchOptions _options;
+    private readonly ILogger<EmbeddingService> _logger;
+
+    public EmbeddingService(HttpClient httpClient, SemanticSearchOptions options, ILogger<EmbeddingService> logger)
+    {
+        _httpClient = httpClient;
+        _options = options;
+        _logger = logger;
+        if (_options.EmbeddingTimeoutSeconds > 0)
+        {
+            _httpClient.Timeout = TimeSpan.FromSeconds(_options.EmbeddingTimeoutSeconds);
+        }
+        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+
+    public async Task<float[]?> EmbedAsync(string text, CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled || string.IsNullOrWhiteSpace(_options.EmbeddingEndpoint) || string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        try
+        {
+            var requestBody = new EmbeddingRequest { Model = _options.EmbeddingModel, Prompt = text };
+            var content = new StringContent(JsonSerializer.Serialize(requestBody, JsonSerializerConfig.Default), Encoding.UTF8, "application/json");
+            var response = await _httpClient.PostAsync(_options.EmbeddingEndpoint, content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning("Embedding backend returned {StatusCode}: {Error}", response.StatusCode, error);
+                return null;
+            }
+
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var parsed = JsonSerializer.Deserialize<EmbeddingResponse>(responseContent, JsonSerializerConfig.Default);
+            var embedding = parsed?.Embedding;
+
+            if (embedding == null || embedding.Length == 0)
+            {
+                _logger.LogWarning("Embedding backend returned an empty embedding");
+                return null;
+            }
+
+            if (embedding.Length != _options.Dimensions)
+            {
+                _logger.LogWarning("Embedding dimension mismatch: expected {Expected}, got {Actual}. Check SemanticSearch:Dimensions vs the model output.",
+                    _options.Dimensions, embedding.Length);
+                return null;
+            }
+
+            return embedding;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to generate embedding; falling back to keyword-only behavior");
+            return null;
+        }
+    }
+
+    private sealed class EmbeddingRequest
+    {
+        [JsonPropertyName("model")] public string Model { get; set; } = string.Empty;
+        [JsonPropertyName("prompt")] public string Prompt { get; set; } = string.Empty;
+    }
+
+    private sealed class EmbeddingResponse
+    {
+        [JsonPropertyName("embedding")] public float[]? Embedding { get; set; }
+    }
+}

--- a/src/HappyNotes.Services/NoteService.cs
+++ b/src/HappyNotes.Services/NoteService.cs
@@ -16,6 +16,8 @@ namespace HappyNotes.Services;
 
 public class NoteService(
     ISearchService searchService,
+    IEmbeddingService embeddingService,
+    SemanticSearchOptions semanticOptions,
     IEnumerable<ISyncNoteService> syncNoteServices,
     INoteTagService noteTagService,
     INoteRepository noteRepository,
@@ -218,8 +220,84 @@ public class NoteService(
 
     public async Task<PageData<Note>> SearchUserNotes(long userId, int pageSize, int pageNumber, string keyword, NoteFilterType filter = NoteFilterType.Normal)
     {
+        if (!semanticOptions.Enabled)
+        {
+            return await _KeywordOnlySearch(userId, pageSize, pageNumber, keyword, filter);
+        }
+
+        // Compute semantic candidates once per query, then dedup them against the keyword hits.
+        // Falls back to keyword-only whenever the embedding backend or KNN search is unavailable.
+        List<long>? semanticExtra = null;
+        var keywordTotal = 0;
+        var keywordCappedIds = new List<long>();
+        try
+        {
+            var queryVector = await embeddingService.EmbedAsync(keyword);
+            if (queryVector != null)
+            {
+                var semanticIds = await searchService.GetSemanticNoteIdsAsync(userId, queryVector, filter, semanticOptions.TopK, semanticOptions.MaxDistance);
+                // Capped keyword set is used ONLY to dedup semantic candidates and to size the merged total —
+                // keyword paging itself is never capped (deep pages are fetched directly below).
+                (keywordCappedIds, keywordTotal) = await searchService.GetNoteIdsByKeywordAsync(userId, keyword, 1, semanticOptions.KeywordMergeCap, filter);
+                var keywordSet = keywordCappedIds.ToHashSet();
+                semanticExtra = semanticIds.Where(id => !keywordSet.Contains(id)).ToList();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Semantic search unavailable; falling back to keyword-only search");
+            semanticExtra = null;
+        }
+
+        if (semanticExtra == null)
+        {
+            return await _KeywordOnlySearch(userId, pageSize, pageNumber, keyword, filter);
+        }
+
+        // Merged order: all keyword hits (positions [0, keywordTotal)) first, then the deduped semantic
+        // extras (positions [keywordTotal, keywordTotal + semanticExtra.Count)). Page over that virtual list.
+        var start = (pageNumber - 1) * pageSize;
+
+        var mergedIds = new List<long>(pageSize);
+        if (start < keywordTotal)
+        {
+            // Keyword slice for this page: reuse the capped set when the window fits inside it,
+            // otherwise query Manticore directly so deep pages past the cap still work.
+            if (start + pageSize <= keywordCappedIds.Count)
+            {
+                mergedIds.AddRange(keywordCappedIds.GetRange(start, Math.Min(pageSize, keywordCappedIds.Count - start)));
+            }
+            else
+            {
+                var (keywordPageIds, _) = await searchService.GetNoteIdsByKeywordAsync(userId, keyword, pageNumber, pageSize, filter);
+                mergedIds.AddRange(keywordPageIds);
+            }
+        }
+
+        // Semantic slice for this page, in semantic-local coordinates.
+        var semStart = Math.Max(0, start - keywordTotal);
+        var semEnd = Math.Min(semanticExtra.Count, start + pageSize - keywordTotal);
+        for (var i = semStart; i < semEnd; i++)
+        {
+            mergedIds.Add(semanticExtra[i]);
+        }
+
+        var mergedTotal = keywordTotal + semanticExtra.Count;
+        var notes = await _GetNotesByIdsOrdered(mergedIds);
+        return new PageData<Note>()
+        {
+            DataList = notes,
+            PageIndex = pageNumber,
+            PageSize = pageSize,
+            TotalCount = mergedTotal,
+        };
+    }
+
+    private async Task<PageData<Note>> _KeywordOnlySearch(long userId, int pageSize, int pageNumber, string keyword, NoteFilterType filter)
+    {
         var (noteIds, total) = await searchService.GetNoteIdsByKeywordAsync(userId, keyword, pageNumber, pageSize, filter);
-        var notes = await _GetNotesByIds(noteIds);
+        // Preserve Manticore's score/date ranking (the SQL IN fetch does not), consistent with the merged path.
+        var notes = await _GetNotesByIdsOrdered(noteIds);
         return new PageData<Note>()
         {
             DataList = notes,
@@ -549,5 +627,25 @@ public class NoteService(
         }
 
         return await noteRepository.GetListByIdsAsync(noteIds.ToArray());
+    }
+
+    /// <summary>
+    /// Fetches notes by id and returns them in the exact order of <paramref name="noteIds"/>.
+    /// GetListByIdsAsync uses a SQL IN clause which does not preserve order, so the merged
+    /// keyword-then-semantic ranking must be re-applied here.
+    /// </summary>
+    private async Task<IList<Note>> _GetNotesByIdsOrdered(IList<long> noteIds)
+    {
+        var notes = await _GetNotesByIds(noteIds);
+        var byId = notes.ToDictionary(n => n.Id);
+        var ordered = new List<Note>(noteIds.Count);
+        foreach (var id in noteIds)
+        {
+            if (byId.TryGetValue(id, out var note))
+            {
+                ordered.Add(note);
+            }
+        }
+        return ordered;
     }
 }

--- a/src/HappyNotes.Services/NoteVectorBackfillService.cs
+++ b/src/HappyNotes.Services/NoteVectorBackfillService.cs
@@ -1,0 +1,158 @@
+using Api.Framework;
+using HappyNotes.Entities;
+using HappyNotes.Repositories.interfaces;
+using HappyNotes.Services.interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace HappyNotes.Services;
+
+/// <summary>
+/// One-off, resumable, batched job that embeds existing notes and stores their vectors in the Manticore
+/// index. Intended to be triggered off-peak (see VectorBackfillAdminController). It walks notes in
+/// id-ascending order and persists the last successfully-embedded id to a cursor file so a restart
+/// resumes rather than re-embedding from scratch.
+/// </summary>
+public class NoteVectorBackfillService : INoteVectorBackfillService
+{
+    private readonly INoteRepository _noteRepository;
+    private readonly IRepositoryBase<LongNote> _longNoteRepository;
+    private readonly ISearchService _searchService;
+    private readonly IEmbeddingService _embeddingService;
+    private readonly SemanticSearchOptions _options;
+    private readonly ILogger<NoteVectorBackfillService> _logger;
+
+    public NoteVectorBackfillService(
+        INoteRepository noteRepository,
+        IRepositoryBase<LongNote> longNoteRepository,
+        ISearchService searchService,
+        IEmbeddingService embeddingService,
+        SemanticSearchOptions options,
+        ILogger<NoteVectorBackfillService> logger)
+    {
+        _noteRepository = noteRepository;
+        _longNoteRepository = longNoteRepository;
+        _searchService = searchService;
+        _embeddingService = embeddingService;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<VectorBackfillResult> RunAsync(int? batchSize = null, CancellationToken cancellationToken = default)
+    {
+        var result = new VectorBackfillResult();
+
+        if (!_options.Enabled)
+        {
+            result.Completed = false;
+            result.Message = "SemanticSearch is disabled; nothing to backfill.";
+            return result;
+        }
+
+        var size = batchSize ?? _options.BackfillBatchSize;
+        if (size <= 0) size = 100;
+
+        var cursor = _ReadCursor();
+        _logger.LogInformation("Vector backfill starting from note id > {Cursor}, batch size {BatchSize}", cursor, size);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var notes = await _noteRepository.GetTopListAsync(size, w => w.Id > cursor, new List<string> { "Id ASC" });
+            if (notes.Count == 0)
+            {
+                result.Completed = true;
+                break;
+            }
+
+            foreach (var note in notes)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var fullContent = await _ReconstructFullContent(note);
+                if (string.IsNullOrWhiteSpace(fullContent))
+                {
+                    cursor = note.Id;
+                    result.Processed++;
+                    result.Skipped++;
+                    continue;
+                }
+
+                var embedding = await _embeddingService.EmbedAsync(fullContent, cancellationToken);
+                if (embedding == null)
+                {
+                    // Backend unavailable (or dimension mismatch): stop and keep the cursor at the last
+                    // success so the operator can fix the backend and resume without losing progress.
+                    _WriteCursor(cursor);
+                    result.LastProcessedId = cursor;
+                    result.Completed = false;
+                    result.Message = $"Stopped at note {note.Id}: embedding backend unavailable. Rerun to resume.";
+                    _logger.LogWarning("Vector backfill stopped at note {NoteId}: embedding backend unavailable", note.Id);
+                    return result;
+                }
+
+                await _searchService.SyncNoteToIndexAsync(note, fullContent, embedding);
+                cursor = note.Id;
+                result.Processed++;
+                result.Embedded++;
+            }
+
+            _WriteCursor(cursor);
+            result.LastProcessedId = cursor;
+            _logger.LogInformation("Vector backfill progress: {Processed} processed ({Embedded} embedded, {Skipped} skipped), cursor at {Cursor}",
+                result.Processed, result.Embedded, result.Skipped, cursor);
+
+            if (notes.Count < size)
+            {
+                result.Completed = true;
+                break;
+            }
+        }
+
+        result.LastProcessedId = cursor;
+        result.Message ??= result.Completed
+            ? $"Backfill complete: {result.Embedded} embedded, {result.Skipped} skipped."
+            : "Backfill cancelled.";
+        return result;
+    }
+
+    private async Task<string> _ReconstructFullContent(Note note)
+    {
+        if (note.IsLong)
+        {
+            var longNote = await _longNoteRepository.GetFirstOrDefaultAsync(x => x.Id == note.Id);
+            return longNote?.Content ?? note.Content ?? string.Empty;
+        }
+        return note.Content ?? string.Empty;
+    }
+
+    private long _ReadCursor()
+    {
+        try
+        {
+            if (File.Exists(_options.BackfillCursorPath))
+            {
+                var text = File.ReadAllText(_options.BackfillCursorPath).Trim();
+                if (long.TryParse(text, out var value))
+                {
+                    return value;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read backfill cursor at {Path}; starting from 0", _options.BackfillCursorPath);
+        }
+        return 0;
+    }
+
+    private void _WriteCursor(long cursor)
+    {
+        try
+        {
+            File.WriteAllText(_options.BackfillCursorPath, cursor.ToString());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist backfill cursor {Cursor} to {Path}", cursor, _options.BackfillCursorPath);
+        }
+    }
+}

--- a/src/HappyNotes.Services/SearchService.cs
+++ b/src/HappyNotes.Services/SearchService.cs
@@ -69,25 +69,29 @@ public class SearchService : ISearchService
         return (noteIdList, (int)total);
     }
 
-    public async Task SyncNoteToIndexAsync(Note note, string fullContent)
+    public async Task SyncNoteToIndexAsync(Note note, string fullContent, float[]? embedding = null)
     {
-        var requestBody = new
+        var doc = new Dictionary<string, object>
         {
-            index = "noteindex",
-            id = note.Id,
-            doc = new
-            {
-                userid = note.UserId,
-                islong = note.IsLong ? 1 : 0,
-                isprivate = note.IsPrivate ? 1 : 0,
-                ismarkdown = note.IsMarkdown ? 1 : 0,
-                content = fullContent,
-                tags = string.Join(" ", fullContent.GetTags()),
-                createdat = note.CreatedAt,
-                updatedat = note.UpdatedAt ?? 0,
-                deletedat = note.DeletedAt ?? 0
-            }
+            ["userid"] = note.UserId,
+            ["islong"] = note.IsLong ? 1 : 0,
+            ["isprivate"] = note.IsPrivate ? 1 : 0,
+            ["ismarkdown"] = note.IsMarkdown ? 1 : 0,
+            ["content"] = fullContent,
+            ["tags"] = string.Join(" ", fullContent.GetTags()),
+            ["createdat"] = note.CreatedAt,
+            ["updatedat"] = note.UpdatedAt ?? 0,
+            ["deletedat"] = note.DeletedAt ?? 0
         };
+
+        // The vector rides in the same REPLACE as the content. REPLACE rewrites the whole doc, so a note's
+        // vector is only preserved when the writer that rewrites the content also supplies the vector.
+        if (embedding != null)
+        {
+            doc["embedding"] = embedding;
+        }
+
+        var requestBody = new { index = "noteindex", id = note.Id, doc };
 
         var content = new StringContent(JsonSerializer.Serialize(requestBody, JsonSerializerConfig.Default), Encoding.UTF8, "application/json");
         var response = await _httpClient.PostAsync("json/replace", content);
@@ -97,6 +101,64 @@ public class SearchService : ISearchService
             var errorContent = await response.Content.ReadAsStringAsync();
             throw new Exception($"ManticoreSearch replace operation failed: {response.StatusCode} - {errorContent}");
         }
+    }
+
+    public async Task<List<long>> GetSemanticNoteIdsAsync(long userId, float[] queryVector, NoteFilterType filter, int k, double maxDistance = 0)
+    {
+        if (queryVector.Length == 0 || k <= 0)
+            return new List<long>();
+
+        // knn.query carries the search vector; the sibling top-level "query" carries the owner/delete-state
+        // filter (identical clauses to the keyword path) so vector search can never leak another user's or a
+        // soft-deleted note. See https://manual.manticoresearch.com/Searching/KNN (filter via sibling query).
+        var queryObject = new Dictionary<string, object>
+        {
+            { "table", "noteindex" },
+            {
+                "knn", new Dictionary<string, object>
+                {
+                    { "field", "embedding" },
+                    { "query", queryVector },
+                    { "k", k }
+                }
+            },
+            {
+                "query", new Dictionary<string, object>
+                {
+                    { "bool", new Dictionary<string, object> { { "must", _BuildOwnerFilterClauses(userId, filter) } } }
+                }
+            },
+            { "limit", k },
+            { "_source", new[] { "id" } }
+        };
+
+        var content = new StringContent(JsonSerializer.Serialize(queryObject, JsonSerializerConfig.Default), Encoding.UTF8, "application/json");
+        var response = await _httpClient.PostAsync("json/search", content);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            throw new Exception($"ManticoreSearch KNN search failed: {response.StatusCode} - {errorContent}");
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var searchResult = JsonSerializer.Deserialize<ManticoreSearchResult>(responseContent, JsonSerializerConfig.Default);
+
+        var noteIdList = new List<long>();
+        if (searchResult?.hits?.hits != null)
+        {
+            foreach (var hit in searchResult.hits.hits)
+            {
+                if (hit?._source == null)
+                    continue;
+                // Hits arrive nearest-first; apply the optional distance ceiling.
+                if (maxDistance > 0 && hit._knn_dist > maxDistance)
+                    continue;
+                noteIdList.Add(hit._id);
+            }
+        }
+
+        return noteIdList;
     }
 
     public async Task DeleteNoteFromIndexAsync(long id)
@@ -227,18 +289,10 @@ public class SearchService : ISearchService
                         { "minimum_should_match", 1 } // At least one of the "should" clauses must match
                     }
                 }
-            },
-            new Dictionary<string, object> { { "equals", new Dictionary<string, long> { { "UserId", userId } } } }
+            }
         };
-
-        if (filter == NoteFilterType.Normal)
-        {
-            mustClauses.Add(new Dictionary<string, object> { { "equals", new Dictionary<string, long> { { "DeletedAt", 0 } } } });
-        }
-        else
-        {
-            mustClauses.Add(new Dictionary<string, object> { { "range", new Dictionary<string, object> { { "DeletedAt", new Dictionary<string, long> { { "gt", 0 } } } } } });
-        }
+        // Owner + delete-state isolation is shared verbatim with the KNN path via _BuildOwnerFilterClauses.
+        mustClauses.AddRange(_BuildOwnerFilterClauses(userId, filter));
         var source = new[] { "id" };
 
         return new Dictionary<string, object>
@@ -264,5 +318,29 @@ public class SearchService : ISearchService
             },
             {"_source", source}
         };
+    }
+
+    /// <summary>
+    /// Owner + delete-state isolation clauses, shared by the keyword and KNN search paths so vector
+    /// search enforces exactly the same access boundary: own notes only (private included), and either
+    /// non-deleted (Normal) or deleted-only (Deleted) — never another user's or a soft-deleted note.
+    /// </summary>
+    private static List<object> _BuildOwnerFilterClauses(long userId, NoteFilterType filter)
+    {
+        var clauses = new List<object>
+        {
+            new Dictionary<string, object> { { "equals", new Dictionary<string, long> { { "UserId", userId } } } }
+        };
+
+        if (filter == NoteFilterType.Normal)
+        {
+            clauses.Add(new Dictionary<string, object> { { "equals", new Dictionary<string, long> { { "DeletedAt", 0 } } } });
+        }
+        else
+        {
+            clauses.Add(new Dictionary<string, object> { { "range", new Dictionary<string, object> { { "DeletedAt", new Dictionary<string, long> { { "gt", 0 } } } } } });
+        }
+
+        return clauses;
     }
 }

--- a/src/HappyNotes.Services/SemanticSearchOptions.cs
+++ b/src/HappyNotes.Services/SemanticSearchOptions.cs
@@ -1,0 +1,50 @@
+namespace HappyNotes.Services;
+
+/// <summary>
+/// Configuration for semantic (vector) note search. When <see cref="Enabled"/> is false the
+/// search path behaves exactly like the legacy keyword-only search.
+/// </summary>
+public class SemanticSearchOptions
+{
+    /// <summary>Master switch. When false, no embeddings are generated and search stays keyword-only.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Self-hosted embedding endpoint (default: Ollama). Expected request/response shape:
+    /// POST { "model": "&lt;model&gt;", "prompt": "&lt;text&gt;" } -> { "embedding": [floats] }.
+    /// </summary>
+    public string EmbeddingEndpoint { get; set; } = string.Empty;
+
+    /// <summary>Embedding model name passed to the endpoint (e.g. bge-m3).</summary>
+    public string EmbeddingModel { get; set; } = "bge-m3";
+
+    /// <summary>Vector dimension. Must match both the model output and the noteindex float_vector knn_dims.</summary>
+    public int Dimensions { get; set; } = 1024;
+
+    /// <summary>HNSW similarity metric documented in create_table.sql (cosine for bge-m3).</summary>
+    public string Similarity { get; set; } = "cosine";
+
+    /// <summary>Number of nearest semantic candidates to retrieve per query.</summary>
+    public int TopK { get; set; } = 50;
+
+    /// <summary>
+    /// Optional distance ceiling on the KNN result. Manticore returns _knn_dist (lower = closer);
+    /// candidates with _knn_dist greater than this are dropped. 0 disables the ceiling.
+    /// </summary>
+    public double MaxDistance { get; set; } = 0;
+
+    /// <summary>
+    /// Upper bound on keyword hits fetched purely to dedup semantic candidates against keyword hits.
+    /// Keyword paging itself is NOT capped by this — deep pages are fetched directly from Manticore.
+    /// </summary>
+    public int KeywordMergeCap { get; set; } = 1000;
+
+    /// <summary>Per-call embedding HTTP timeout. Bounds how long a slow backend can block the sync queue.</summary>
+    public int EmbeddingTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>Batch size for the resumable backfill job.</summary>
+    public int BackfillBatchSize { get; set; } = 100;
+
+    /// <summary>File path where the backfill job persists its resume cursor (last embedded note id).</summary>
+    public string BackfillCursorPath { get; set; } = "vector-backfill.cursor";
+}

--- a/src/HappyNotes.Services/SyncQueue/Handlers/ManticoreSearchSyncHandler.cs
+++ b/src/HappyNotes.Services/SyncQueue/Handlers/ManticoreSearchSyncHandler.cs
@@ -15,6 +15,7 @@ namespace HappyNotes.Services.SyncQueue.Handlers;
 public class ManticoreSearchSyncHandler : ISyncHandler
 {
     private readonly ISearchService _searchService;
+    private readonly IEmbeddingService _embeddingService;
     private readonly INoteRepository _noteRepository;
     private readonly SyncQueueOptions _options;
     private readonly ILogger<ManticoreSearchSyncHandler> _logger;
@@ -27,11 +28,13 @@ public class ManticoreSearchSyncHandler : ISyncHandler
 
     public ManticoreSearchSyncHandler(
         ISearchService searchService,
+        IEmbeddingService embeddingService,
         INoteRepository noteRepository,
         IOptions<SyncQueueOptions> options,
         ILogger<ManticoreSearchSyncHandler> logger)
     {
         _searchService = searchService;
+        _embeddingService = embeddingService;
         _noteRepository = noteRepository;
         _options = options.Value;
         _logger = logger;
@@ -100,8 +103,9 @@ public class ManticoreSearchSyncHandler : ISyncHandler
     {
         try
         {
-            await _searchService.SyncNoteToIndexAsync(note, payload.FullContent);
-            _logger.LogDebug("Successfully created ManticoreSearch index entry for note {NoteId}", note.Id);
+            var embedding = await _embeddingService.EmbedAsync(payload.FullContent);
+            await _searchService.SyncNoteToIndexAsync(note, payload.FullContent, embedding);
+            _logger.LogDebug("Successfully created ManticoreSearch index entry for note {NoteId} (vector: {HasVector})", note.Id, embedding != null);
             return true;
         }
         catch (Exception ex)
@@ -115,8 +119,12 @@ public class ManticoreSearchSyncHandler : ISyncHandler
     {
         try
         {
-            await _searchService.SyncNoteToIndexAsync(note, payload.FullContent);
-            _logger.LogDebug("Successfully updated ManticoreSearch index entry for note {NoteId}", note.Id);
+            // Regenerate the vector on every content change: REPLACE rewrites the whole doc, so we must
+            // re-supply the (fresh) vector here or it would be lost. A null embedding (backend down)
+            // degrades this note to keyword-only until the next successful edit or backfill run.
+            var embedding = await _embeddingService.EmbedAsync(payload.FullContent);
+            await _searchService.SyncNoteToIndexAsync(note, payload.FullContent, embedding);
+            _logger.LogDebug("Successfully updated ManticoreSearch index entry for note {NoteId} (vector: {HasVector})", note.Id, embedding != null);
             return true;
         }
         catch (Exception ex)

--- a/src/HappyNotes.Services/interfaces/IEmbeddingService.cs
+++ b/src/HappyNotes.Services/interfaces/IEmbeddingService.cs
@@ -1,0 +1,11 @@
+namespace HappyNotes.Services.interfaces;
+
+public interface IEmbeddingService
+{
+    /// <summary>
+    /// Generates an embedding vector for the given text. Returns null when semantic search is disabled,
+    /// the text is empty, or the embedding backend is unavailable — callers must treat null as
+    /// "no vector available" and fall back to keyword-only behavior.
+    /// </summary>
+    Task<float[]?> EmbedAsync(string text, CancellationToken cancellationToken = default);
+}

--- a/src/HappyNotes.Services/interfaces/INoteVectorBackfillService.cs
+++ b/src/HappyNotes.Services/interfaces/INoteVectorBackfillService.cs
@@ -1,0 +1,23 @@
+namespace HappyNotes.Services.interfaces;
+
+public interface INoteVectorBackfillService
+{
+    /// <summary>
+    /// Embeds existing notes in id-ascending batches and writes their vectors to the index.
+    /// Resumable: progress is persisted to a cursor file, so a stopped/failed run continues where it left off.
+    /// </summary>
+    Task<VectorBackfillResult> RunAsync(int? batchSize = null, CancellationToken cancellationToken = default);
+}
+
+public class VectorBackfillResult
+{
+    public int Processed { get; set; }
+    public int Embedded { get; set; }
+    public int Skipped { get; set; }
+    public long LastProcessedId { get; set; }
+
+    /// <summary>True when the whole corpus was processed; false when the run stopped early (e.g. backend down) and can be resumed.</summary>
+    public bool Completed { get; set; }
+
+    public string? Message { get; set; }
+}

--- a/src/HappyNotes.Services/interfaces/ISearchService.cs
+++ b/src/HappyNotes.Services/interfaces/ISearchService.cs
@@ -6,7 +6,20 @@ namespace HappyNotes.Services.interfaces;
 public interface ISearchService
 {
     Task<(List<long> noteIds, int total)> GetNoteIdsByKeywordAsync(long userId, string query, int pageNumber, int pageSize, NoteFilterType filter = NoteFilterType.Normal);
-    Task SyncNoteToIndexAsync(Note note, string fullContent);
+
+    /// <summary>
+    /// Returns note ids ranked by vector similarity (nearest first), filtered by owner and delete-state
+    /// identically to the keyword path. Candidates with distance above <paramref name="maxDistance"/>
+    /// (when &gt; 0) are dropped.
+    /// </summary>
+    Task<List<long>> GetSemanticNoteIdsAsync(long userId, float[] queryVector, NoteFilterType filter, int k, double maxDistance = 0);
+
+    /// <summary>
+    /// Upserts the note into the index via REPLACE. When <paramref name="embedding"/> is non-null the
+    /// vector is written in the same REPLACE (Manticore REPLACE is the only way to set a float_vector,
+    /// so a single writer per doc avoids clobbering the vector).
+    /// </summary>
+    Task SyncNoteToIndexAsync(Note note, string fullContent, float[]? embedding = null);
     Task DeleteNoteFromIndexAsync(long id);
     Task UndeleteNoteFromIndexAsync(long id);
     Task PurgeUserDeletedNotesFromIndexAsync(long userId);

--- a/tests/HappyNotes.Services.Tests/EmbeddingServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/EmbeddingServiceTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using HappyNotes.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace HappyNotes.Services.Tests;
+
+[TestFixture]
+public class EmbeddingServiceTests
+{
+    private Mock<HttpMessageHandler> _mockHandler = null!;
+    private Mock<ILogger<EmbeddingService>> _mockLogger = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockHandler = new Mock<HttpMessageHandler>();
+        _mockLogger = new Mock<ILogger<EmbeddingService>>();
+    }
+
+    private EmbeddingService CreateService(SemanticSearchOptions options)
+    {
+        var httpClient = new HttpClient(_mockHandler.Object) { BaseAddress = new Uri("http://127.0.0.1:11434") };
+        return new EmbeddingService(httpClient, options, _mockLogger.Object);
+    }
+
+    private void SetupResponse(HttpStatusCode status, string content)
+    {
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = status, Content = new StringContent(content) });
+    }
+
+    [Test]
+    public async Task EmbedAsync_WhenDisabled_ReturnsNullWithoutCallingBackend()
+    {
+        var service = CreateService(new SemanticSearchOptions { Enabled = false, EmbeddingEndpoint = "api/embeddings" });
+
+        var result = await service.EmbedAsync("hello");
+
+        Assert.That(result, Is.Null);
+        _mockHandler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public async Task EmbedAsync_WhenEmptyText_ReturnsNull()
+    {
+        var service = CreateService(new SemanticSearchOptions { Enabled = true, EmbeddingEndpoint = "api/embeddings" });
+
+        var result = await service.EmbedAsync("   ");
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task EmbedAsync_Success_ReturnsEmbedding()
+    {
+        SetupResponse(HttpStatusCode.OK, "{\"embedding\":[0.1,0.2,0.3]}");
+        var service = CreateService(new SemanticSearchOptions { Enabled = true, EmbeddingEndpoint = "api/embeddings", Dimensions = 3 });
+
+        var result = await service.EmbedAsync("hello");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Length, Is.EqualTo(3));
+        Assert.That(result[0], Is.EqualTo(0.1f).Within(0.0001f));
+    }
+
+    [Test]
+    public async Task EmbedAsync_DimensionMismatch_ReturnsNull()
+    {
+        SetupResponse(HttpStatusCode.OK, "{\"embedding\":[0.1,0.2,0.3]}");
+        var service = CreateService(new SemanticSearchOptions { Enabled = true, EmbeddingEndpoint = "api/embeddings", Dimensions = 1024 });
+
+        var result = await service.EmbedAsync("hello");
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task EmbedAsync_BackendError_ReturnsNull()
+    {
+        SetupResponse(HttpStatusCode.InternalServerError, "boom");
+        var service = CreateService(new SemanticSearchOptions { Enabled = true, EmbeddingEndpoint = "api/embeddings", Dimensions = 3 });
+
+        var result = await service.EmbedAsync("hello");
+
+        Assert.That(result, Is.Null);
+    }
+}

--- a/tests/HappyNotes.Services.Tests/ManticoreSearchSyncHandlerTests.cs
+++ b/tests/HappyNotes.Services.Tests/ManticoreSearchSyncHandlerTests.cs
@@ -16,6 +16,7 @@ namespace HappyNotes.Services.Tests;
 public class ManticoreSearchSyncHandlerTests
 {
     private Mock<ISearchService> _mockSearchService;
+    private Mock<IEmbeddingService> _mockEmbeddingService;
     private Mock<INoteRepository> _mockNoteRepository;
     private Mock<IOptions<SyncQueueOptions>> _mockSyncQueueOptions;
     private Mock<ILogger<ManticoreSearchSyncHandler>> _mockLogger;
@@ -27,6 +28,7 @@ public class ManticoreSearchSyncHandlerTests
     public void Setup()
     {
         _mockSearchService = new Mock<ISearchService>();
+        _mockEmbeddingService = new Mock<IEmbeddingService>();
         _mockNoteRepository = new Mock<INoteRepository>();
         _mockSyncQueueOptions = new Mock<IOptions<SyncQueueOptions>>();
         _mockLogger = new Mock<ILogger<ManticoreSearchSyncHandler>>();
@@ -34,8 +36,14 @@ public class ManticoreSearchSyncHandlerTests
         var syncQueueOptions = new SyncQueueOptions();
         _mockSyncQueueOptions.Setup(x => x.Value).Returns(syncQueueOptions);
 
+        // Default: embedding backend "unavailable" so existing content-sync assertions see a null vector.
+        // Tests that exercise the vector path override this.
+        _mockEmbeddingService.Setup(x => x.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((float[]?)null);
+
         _manticoreSearchSyncHandler = new ManticoreSearchSyncHandler(
             _mockSearchService.Object,
+            _mockEmbeddingService.Object,
             _mockNoteRepository.Object,
             _mockSyncQueueOptions.Object,
             _mockLogger.Object);
@@ -62,6 +70,27 @@ public class ManticoreSearchSyncHandlerTests
         // Assert
         Assert.That(result.IsSuccess, Is.True);
         _mockSearchService.Verify(x => x.SyncNoteToIndexAsync(note, "Test content"), Times.Once);
+    }
+
+    [Test]
+    public async Task ProcessAsync_CreateAction_EmbedsContent_AndPassesVectorToIndex()
+    {
+        // Arrange
+        var note = new Note { Id = 1, UserId = 123, Content = "Test content" };
+        var payload = new ManticoreSearchSyncPayload { Action = "CREATE", FullContent = "Test content" };
+        var task = CreateTask("CREATE", 1, 123, payload);
+        var vector = new[] { 0.1f, 0.2f, 0.3f };
+
+        _mockNoteRepository.Setup(x => x.Get(1)).ReturnsAsync(note);
+        _mockEmbeddingService.Setup(x => x.EmbedAsync("Test content", It.IsAny<CancellationToken>())).ReturnsAsync(vector);
+
+        // Act
+        var result = await _manticoreSearchSyncHandler.ProcessAsync(task, CancellationToken.None);
+
+        // Assert
+        Assert.That(result.IsSuccess, Is.True);
+        _mockEmbeddingService.Verify(x => x.EmbedAsync("Test content", It.IsAny<CancellationToken>()), Times.Once);
+        _mockSearchService.Verify(x => x.SyncNoteToIndexAsync(note, "Test content", vector), Times.Once);
     }
 
     private SyncTask CreateTask(string action, long entityId, long userId, ManticoreSearchSyncPayload payload)

--- a/tests/HappyNotes.Services.Tests/NoteServiceSemanticSearchTests.cs
+++ b/tests/HappyNotes.Services.Tests/NoteServiceSemanticSearchTests.cs
@@ -1,0 +1,132 @@
+using Api.Framework;
+using Api.Framework.Models;
+using AutoMapper;
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Repositories.interfaces;
+using HappyNotes.Services;
+using HappyNotes.Services.interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+
+namespace HappyNotes.Services.Tests;
+
+/// <summary>
+/// Covers the semantic merge in NoteService.SearchUserNotes: keyword-first ordering, dedup of semantic
+/// candidates against keyword hits, paging across the merged virtual list, and keyword-only fallback.
+/// </summary>
+[TestFixture]
+public class NoteServiceSemanticSearchTests
+{
+    private Mock<ISearchService> _searchService = null!;
+    private Mock<IEmbeddingService> _embeddingService = null!;
+    private Mock<INoteRepository> _noteRepository = null!;
+    private SemanticSearchOptions _options = null!;
+    private NoteService _noteService = null!;
+
+    private const long UserId = 42;
+    private const string Keyword = "hello world";
+
+    [SetUp]
+    public void Setup()
+    {
+        _searchService = new Mock<ISearchService>();
+        _embeddingService = new Mock<IEmbeddingService>();
+        _noteRepository = new Mock<INoteRepository>();
+        _options = new SemanticSearchOptions { Enabled = true, TopK = 50, KeywordMergeCap = 1000, MaxDistance = 0 };
+
+        // Return notes in reversed order to prove the merged ordering is re-applied after the SQL IN fetch.
+        _noteRepository.Setup(r => r.GetListByIdsAsync(It.IsAny<long[]>()))
+            .ReturnsAsync((long[] ids) => ids.Reverse().Select(id => new Note { Id = id }).ToList());
+
+        _noteService = new NoteService(
+            _searchService.Object,
+            _embeddingService.Object,
+            _options,
+            new[] { new Mock<ISyncNoteService>().Object },
+            new Mock<INoteTagService>().Object,
+            _noteRepository.Object,
+            new Mock<IRepositoryBase<LongNote>>().Object,
+            new Mock<IMapper>().Object,
+            new Mock<ILogger<NoteService>>().Object,
+            new FakeTimeProvider());
+    }
+
+    private void SetupEmbedding() =>
+        _embeddingService.Setup(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { 0.1f, 0.2f });
+
+    private void SetupSemantic(params long[] ids) =>
+        _searchService.Setup(s => s.GetSemanticNoteIdsAsync(UserId, It.IsAny<float[]>(), It.IsAny<NoteFilterType>(), It.IsAny<int>(), It.IsAny<double>()))
+            .ReturnsAsync(ids.ToList());
+
+    private void SetupKeyword(int pageNumber, int pageSize, List<long> ids, int total) =>
+        _searchService.Setup(s => s.GetNoteIdsByKeywordAsync(UserId, Keyword, pageNumber, pageSize, It.IsAny<NoteFilterType>()))
+            .ReturnsAsync((ids, total));
+
+    private static List<long> Ids(PageData<Note> page) => page.DataList.Select(n => n.Id).ToList();
+
+    [Test]
+    public async Task Disabled_UsesKeywordOnly_AndDoesNotEmbed()
+    {
+        _options.Enabled = false;
+        SetupKeyword(1, 10, new List<long> { 1, 2 }, 2);
+
+        var result = await _noteService.SearchUserNotes(UserId, 10, 1, Keyword);
+
+        Assert.That(result.TotalCount, Is.EqualTo(2));
+        CollectionAssert.AreEqual(new List<long> { 1, 2 }, Ids(result));
+        _embeddingService.Verify(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _searchService.Verify(s => s.GetSemanticNoteIdsAsync(It.IsAny<long>(), It.IsAny<float[]>(), It.IsAny<NoteFilterType>(), It.IsAny<int>(), It.IsAny<double>()), Times.Never);
+    }
+
+    [Test]
+    public async Task EmbeddingUnavailable_FallsBackToKeywordOnly()
+    {
+        _embeddingService.Setup(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((float[]?)null);
+        SetupKeyword(1, 10, new List<long> { 1, 2 }, 2);
+
+        var result = await _noteService.SearchUserNotes(UserId, 10, 1, Keyword);
+
+        Assert.That(result.TotalCount, Is.EqualTo(2));
+        CollectionAssert.AreEqual(new List<long> { 1, 2 }, Ids(result));
+        _searchService.Verify(s => s.GetSemanticNoteIdsAsync(It.IsAny<long>(), It.IsAny<float[]>(), It.IsAny<NoteFilterType>(), It.IsAny<int>(), It.IsAny<double>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Merge_KeywordFirstThenSemantic_DedupsAndOrders()
+    {
+        SetupEmbedding();
+        SetupSemantic(3, 4, 5);                       // 3 duplicates a keyword hit -> extras [4,5]
+        SetupKeyword(1, _options.KeywordMergeCap, new List<long> { 1, 2, 3 }, 3); // capped set + real total
+        SetupKeyword(1, 10, new List<long> { 1, 2, 3 }, 3);                        // this-page keyword slice
+
+        var result = await _noteService.SearchUserNotes(UserId, 10, 1, Keyword);
+
+        Assert.That(result.TotalCount, Is.EqualTo(5), "total = keyword hits + deduped semantic extras");
+        CollectionAssert.AreEqual(new List<long> { 1, 2, 3, 4, 5 }, Ids(result));
+    }
+
+    [Test]
+    public async Task Merge_PagesAcrossKeywordAndSemanticTail_LaterPagesNotEmpty()
+    {
+        // keyword hits: [1,2,3] (total 3); semantic extras after dedup: [4,5,6,7]; page size 2.
+        SetupEmbedding();
+        SetupSemantic(4, 5, 6, 7);
+        SetupKeyword(1, _options.KeywordMergeCap, new List<long> { 1, 2, 3 }, 3);
+        SetupKeyword(2, 2, new List<long> { 3 }, 3);   // deep page beyond capped-slice window -> direct query
+
+        var page1 = await _noteService.SearchUserNotes(UserId, 2, 1, Keyword);
+        var page2 = await _noteService.SearchUserNotes(UserId, 2, 2, Keyword);
+        var page3 = await _noteService.SearchUserNotes(UserId, 2, 3, Keyword);
+        var page4 = await _noteService.SearchUserNotes(UserId, 2, 4, Keyword);
+
+        Assert.That(page1.TotalCount, Is.EqualTo(7));
+        CollectionAssert.AreEqual(new List<long> { 1, 2 }, Ids(page1));   // pure keyword
+        CollectionAssert.AreEqual(new List<long> { 3, 4 }, Ids(page2));   // straddle: keyword tail + semantic head
+        CollectionAssert.AreEqual(new List<long> { 5, 6 }, Ids(page3));   // pure semantic
+        CollectionAssert.AreEqual(new List<long> { 7 }, Ids(page4));      // semantic tail, not empty
+    }
+}

--- a/tests/HappyNotes.Services.Tests/NoteServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/NoteServiceTests.cs
@@ -21,6 +21,8 @@ namespace HappyNotes.Services.Tests;
 public class NoteServiceTests
 {
     private Mock<ISearchService> _searchService;
+    private Mock<IEmbeddingService> _mockEmbeddingService;
+    private SemanticSearchOptions _semanticSearchOptions;
     private Mock<ISyncNoteService> _mockSyncNoteService;
     private Mock<INoteTagService> _mockNoteTagService;
     private Mock<INoteRepository> _mockNoteRepository;
@@ -34,6 +36,8 @@ public class NoteServiceTests
     public void Setup()
     {
         _searchService = new Mock<ISearchService>();
+        _mockEmbeddingService = new Mock<IEmbeddingService>();
+        _semanticSearchOptions = new SemanticSearchOptions { Enabled = false };
         _mockSyncNoteService = new Mock<ISyncNoteService>();
         var syncServices = new[] { _mockSyncNoteService.Object };
         _mockNoteTagService = new Mock<INoteTagService>();
@@ -53,6 +57,8 @@ public class NoteServiceTests
 
         _noteService = new NoteService(
             _searchService.Object,
+            _mockEmbeddingService.Object,
+            _semanticSearchOptions,
             syncServices,
             _mockNoteTagService.Object,
             _mockNoteRepository.Object,
@@ -625,6 +631,8 @@ public class NoteServiceTests
     public class GetTimestampsTests
     {
         private Mock<ISearchService> _searchService;
+        private Mock<IEmbeddingService> _mockEmbeddingService;
+        private SemanticSearchOptions _semanticSearchOptions;
         private Mock<ISyncNoteService> _mockSyncNoteService;
         private Mock<INoteTagService> _mockNoteTagService;
         private Mock<INoteRepository> _mockNoteRepository;
@@ -638,6 +646,8 @@ public class NoteServiceTests
         public void Setup()
         {
             _searchService = new Mock<ISearchService>();
+            _mockEmbeddingService = new Mock<IEmbeddingService>();
+            _semanticSearchOptions = new SemanticSearchOptions { Enabled = false };
             _mockSyncNoteService = new Mock<ISyncNoteService>();
             var syncServices = new[] { _mockSyncNoteService.Object };
             _mockNoteTagService = new Mock<INoteTagService>();
@@ -657,6 +667,8 @@ public class NoteServiceTests
 
             _noteService = new NoteService(
                 _searchService.Object,
+                _mockEmbeddingService.Object,
+                _semanticSearchOptions,
                 syncServices,
                 _mockNoteTagService.Object,
                 _mockNoteRepository.Object,

--- a/tests/HappyNotes.Services.Tests/NoteVectorBackfillServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/NoteVectorBackfillServiceTests.cs
@@ -1,0 +1,101 @@
+using System.Linq.Expressions;
+using Api.Framework;
+using HappyNotes.Entities;
+using HappyNotes.Repositories.interfaces;
+using HappyNotes.Services;
+using HappyNotes.Services.interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace HappyNotes.Services.Tests;
+
+[TestFixture]
+public class NoteVectorBackfillServiceTests
+{
+    private Mock<INoteRepository> _noteRepository = null!;
+    private Mock<IRepositoryBase<LongNote>> _longNoteRepository = null!;
+    private Mock<ISearchService> _searchService = null!;
+    private Mock<IEmbeddingService> _embeddingService = null!;
+    private SemanticSearchOptions _options = null!;
+    private string _cursorPath = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _noteRepository = new Mock<INoteRepository>();
+        _longNoteRepository = new Mock<IRepositoryBase<LongNote>>();
+        _searchService = new Mock<ISearchService>();
+        _embeddingService = new Mock<IEmbeddingService>();
+        _cursorPath = Path.Combine(Path.GetTempPath(), $"vector-backfill-test-{Guid.NewGuid():N}.cursor");
+        _options = new SemanticSearchOptions { Enabled = true, Dimensions = 2, BackfillCursorPath = _cursorPath };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (File.Exists(_cursorPath)) File.Delete(_cursorPath);
+    }
+
+    private NoteVectorBackfillService CreateService() => new(
+        _noteRepository.Object, _longNoteRepository.Object, _searchService.Object,
+        _embeddingService.Object, _options, new Mock<ILogger<NoteVectorBackfillService>>().Object);
+
+    private void SetupBatch(params Note[] notes) =>
+        _noteRepository.Setup(r => r.GetTopListAsync(It.IsAny<int>(), It.IsAny<Expression<Func<Note, bool>>>(), It.IsAny<List<string>>()))
+            .ReturnsAsync(notes.ToList());
+
+    [Test]
+    public async Task RunAsync_Disabled_DoesNothing()
+    {
+        _options.Enabled = false;
+        var result = await CreateService().RunAsync();
+
+        Assert.That(result.Completed, Is.False);
+        Assert.That(result.Embedded, Is.EqualTo(0));
+        _noteRepository.Verify(r => r.GetTopListAsync(It.IsAny<int>(), It.IsAny<Expression<Func<Note, bool>>>(), It.IsAny<List<string>>()), Times.Never);
+    }
+
+    [Test]
+    public async Task RunAsync_EmbedsAllNotes_AndCompletes()
+    {
+        SetupBatch(new Note { Id = 1, Content = "a" }, new Note { Id = 2, Content = "b" });
+        _embeddingService.Setup(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { 0.1f, 0.2f });
+
+        var result = await CreateService().RunAsync();
+
+        Assert.That(result.Completed, Is.True);
+        Assert.That(result.Embedded, Is.EqualTo(2));
+        Assert.That(result.LastProcessedId, Is.EqualTo(2));
+        _searchService.Verify(s => s.SyncNoteToIndexAsync(It.IsAny<Note>(), It.IsAny<string>(), It.IsAny<float[]>()), Times.Exactly(2));
+        Assert.That(File.ReadAllText(_cursorPath).Trim(), Is.EqualTo("2"));
+    }
+
+    [Test]
+    public async Task RunAsync_StopsAndKeepsCursor_WhenBackendUnavailable()
+    {
+        SetupBatch(new Note { Id = 1, Content = "a" }, new Note { Id = 2, Content = "b" });
+        _embeddingService.Setup(e => e.EmbedAsync("a", It.IsAny<CancellationToken>())).ReturnsAsync(new[] { 0.1f, 0.2f });
+        _embeddingService.Setup(e => e.EmbedAsync("b", It.IsAny<CancellationToken>())).ReturnsAsync((float[]?)null);
+
+        var result = await CreateService().RunAsync();
+
+        Assert.That(result.Completed, Is.False, "run stops when the backend returns null for a real note");
+        Assert.That(result.Embedded, Is.EqualTo(1));
+        Assert.That(result.LastProcessedId, Is.EqualTo(1), "cursor stays at the last success so the failed note is retried on resume");
+        Assert.That(File.ReadAllText(_cursorPath).Trim(), Is.EqualTo("1"));
+    }
+
+    [Test]
+    public async Task RunAsync_SkipsEmptyContent_WithoutEmbedding()
+    {
+        SetupBatch(new Note { Id = 1, Content = "   " });
+
+        var result = await CreateService().RunAsync();
+
+        Assert.That(result.Completed, Is.True);
+        Assert.That(result.Skipped, Is.EqualTo(1));
+        Assert.That(result.Embedded, Is.EqualTo(0));
+        _embeddingService.Verify(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
+++ b/tests/HappyNotes.Services.Tests/SearchServiceTests.cs
@@ -324,6 +324,148 @@ public class SearchServiceTests
     }
 
     [Test]
+    public async Task GetSemanticNoteIdsAsync_AppliesOwnerAndDeleteFilters_AndReturnsIdsInOrder()
+    {
+        HttpRequestMessage? captured = null;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"hits\":{\"total\":2,\"hits\":[{\"_id\":7,\"_knn_dist\":0.10,\"_source\":{\"id\":7}},{\"_id\":9,\"_knn_dist\":0.20,\"_source\":{\"id\":9}}]}}")
+            });
+
+        var result = await _searchService.GetSemanticNoteIdsAsync(42, new[] { 0.1f, 0.2f, 0.3f }, NoteFilterType.Normal, 10);
+
+        CollectionAssert.AreEqual(new List<long> { 7, 9 }, result);
+
+        Assert.IsNotNull(captured);
+        var body = await captured!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        // knn block carries the vector and field
+        var knn = root.GetProperty("knn");
+        Assert.That(knn.GetProperty("field").GetString(), Is.EqualTo("embedding"));
+        Assert.That(knn.GetProperty("query").GetArrayLength(), Is.EqualTo(3));
+
+        // sibling top-level query carries the identical owner + delete-state isolation as the keyword path
+        var must = root.GetProperty("query").GetProperty("bool").GetProperty("must");
+        long? userIdFilter = null;
+        long? deletedAtFilter = null;
+        foreach (var clause in must.EnumerateArray())
+        {
+            if (clause.TryGetProperty("equals", out var eq))
+            {
+                if (eq.TryGetProperty("UserId", out var uid)) userIdFilter = uid.GetInt64();
+                if (eq.TryGetProperty("DeletedAt", out var del)) deletedAtFilter = del.GetInt64();
+            }
+        }
+        Assert.That(userIdFilter, Is.EqualTo(42), "KNN query must filter by owner UserId");
+        Assert.That(deletedAtFilter, Is.EqualTo(0), "Normal filter must exclude soft-deleted notes in the KNN query");
+    }
+
+    [Test]
+    public async Task GetSemanticNoteIdsAsync_DeletedFilter_UsesDeletedAtRange()
+    {
+        HttpRequestMessage? captured = null;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"hits\":{\"total\":0,\"hits\":[]}}")
+            });
+
+        await _searchService.GetSemanticNoteIdsAsync(1, new[] { 0.1f }, NoteFilterType.Deleted, 5);
+
+        var body = await captured!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var must = doc.RootElement.GetProperty("query").GetProperty("bool").GetProperty("must");
+        var hasDeletedRange = false;
+        foreach (var clause in must.EnumerateArray())
+        {
+            if (clause.TryGetProperty("range", out var range) && range.TryGetProperty("DeletedAt", out var del)
+                && del.TryGetProperty("gt", out var gt) && gt.GetInt64() == 0)
+            {
+                hasDeletedRange = true;
+            }
+        }
+        Assert.That(hasDeletedRange, Is.True, "Deleted filter must select DeletedAt > 0 in the KNN query");
+    }
+
+    [Test]
+    public async Task GetSemanticNoteIdsAsync_MaxDistance_DropsFartherCandidates()
+    {
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"hits\":{\"total\":3,\"hits\":[{\"_id\":1,\"_knn_dist\":0.10,\"_source\":{\"id\":1}},{\"_id\":2,\"_knn_dist\":0.50,\"_source\":{\"id\":2}},{\"_id\":3,\"_knn_dist\":0.90,\"_source\":{\"id\":3}}]}}")
+            });
+
+        var result = await _searchService.GetSemanticNoteIdsAsync(1, new[] { 0.1f }, NoteFilterType.Normal, 10, maxDistance: 0.6);
+
+        CollectionAssert.AreEqual(new List<long> { 1, 2 }, result);
+    }
+
+    [Test]
+    public async Task SyncNoteToIndexAsync_WithEmbedding_IncludesEmbeddingInReplace()
+    {
+        HttpRequestMessage? captured = null;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"result\":\"success\"}")
+            });
+
+        var note = new Note { Id = 5, UserId = 1, Content = "hi", CreatedAt = 1 };
+        await _searchService.SyncNoteToIndexAsync(note, "hi", new[] { 0.1f, 0.2f });
+
+        var body = await captured!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var embedding = doc.RootElement.GetProperty("doc").GetProperty("embedding");
+        Assert.That(embedding.GetArrayLength(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task SyncNoteToIndexAsync_WithoutEmbedding_OmitsEmbeddingField()
+    {
+        HttpRequestMessage? captured = null;
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("{\"result\":\"success\"}")
+            });
+
+        var note = new Note { Id = 6, UserId = 1, Content = "hi", CreatedAt = 1 };
+        await _searchService.SyncNoteToIndexAsync(note, "hi");
+
+        var body = await captured!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.That(doc.RootElement.GetProperty("doc").TryGetProperty("embedding", out _), Is.False);
+    }
+
+    [Test]
     public async Task PurgeUserDeletedNotesFromIndexAsync_DeletedNotes_RemovesThem()
     {
         // Arrange

--- a/tests/HappyNotes.Services.Tests/SemanticSearchIntegrationTests.cs
+++ b/tests/HappyNotes.Services.Tests/SemanticSearchIntegrationTests.cs
@@ -1,0 +1,74 @@
+using HappyNotes.Common.Enums;
+using HappyNotes.Entities;
+using HappyNotes.Services;
+using HappyNotes.Services.interfaces;
+using Moq;
+
+namespace HappyNotes.Services.Tests;
+
+// Manual integration tests for semantic (KNN) search isolation. They require a running Manticore
+// instance whose `noteindex` has the `Embedding float_vector` column (see docker/create_table.sql).
+// Vectors are injected directly, so no embedding backend (Ollama) is needed to run these.
+// HTTP JSON endpoint defaults to http://127.0.0.1:9308/.
+[TestFixture]
+[Explicit("Manual test - requires local Manticore with the Embedding float_vector column at http://127.0.0.1:9308/")]
+public class SemanticSearchIntegrationTests
+{
+    private const int Dims = 1024;
+    private SearchService _searchService = null!;
+
+    // Two users; a deleted note for user A; distinct ids well above any real data to avoid collisions.
+    private const long UserA = 900001;
+    private const long UserB = 900002;
+    private const long NoteA1 = 990001; // user A, active
+    private const long NoteA2 = 990002; // user A, active
+    private const long NoteADeleted = 990003; // user A, soft-deleted
+    private const long NoteB1 = 990004; // user B, active
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new ManticoreConnectionOptions { HttpEndpoint = "http://127.0.0.1:9308/" };
+        _searchService = new SearchService(new Mock<IDatabaseClient>().Object, new HttpClient(), options);
+    }
+
+    private static float[] Vector(float seed)
+    {
+        var v = new float[Dims];
+        for (var i = 0; i < Dims; i++) v[i] = seed;
+        return v;
+    }
+
+    private Note MakeNote(long id, long userId, long deletedAt) => new()
+    {
+        Id = id,
+        UserId = userId,
+        IsLong = false,
+        IsPrivate = false,
+        IsMarkdown = false,
+        Content = $"note {id}",
+        CreatedAt = 1_700_000_000,
+        UpdatedAt = null,
+        DeletedAt = deletedAt == 0 ? null : deletedAt
+    };
+
+    [Test]
+    public async Task GetSemanticNoteIdsAsync_NeverReturnsOtherUsersOrDeletedNotes()
+    {
+        // Seed: all vectors identical so ranking cannot be the reason a note is excluded — only the filter can.
+        await _searchService.SyncNoteToIndexAsync(MakeNote(NoteA1, UserA, 0), "note", Vector(0.5f));
+        await _searchService.SyncNoteToIndexAsync(MakeNote(NoteA2, UserA, 0), "note", Vector(0.5f));
+        await _searchService.SyncNoteToIndexAsync(MakeNote(NoteADeleted, UserA, 1_700_000_100), "note", Vector(0.5f));
+        await _searchService.SyncNoteToIndexAsync(MakeNote(NoteB1, UserB, 0), "note", Vector(0.5f));
+
+        // Give the RT index a moment to make the docs searchable.
+        await Task.Delay(500);
+
+        var results = await _searchService.GetSemanticNoteIdsAsync(UserA, Vector(0.5f), NoteFilterType.Normal, 50);
+
+        Assert.That(results, Does.Contain(NoteA1));
+        Assert.That(results, Does.Contain(NoteA2));
+        Assert.That(results, Does.Not.Contain(NoteADeleted), "soft-deleted note must not appear under the Normal filter");
+        Assert.That(results, Does.Not.Contain(NoteB1), "another user's note must never appear");
+    }
+}


### PR DESCRIPTION
Closes #53

## What
Adds Manticore-native KNN vector search over the existing `noteindex` and merges its hits into the current `/notes/search` endpoint — transparently to clients (same response shape, zero frontend change). Opt-in via `SemanticSearch:Enabled`; when off, search is byte-for-byte the legacy keyword-only path.

## How
- **Config** `SemanticSearchOptions` + `SemanticSearch` appsettings block (endpoint, model, dims, similarity, TopK, MaxDistance, KeywordMergeCap, timeout, backfill).
- **Embeddings** `EmbeddingService` calls a self-hosted endpoint (Ollama `bge-m3`, 1024-dim, cosine). Every failure path returns null → search degrades to keyword-only, never errors. Embeddings are generated in the background SyncQueue handler, never in the HTTP request path.
- **Index** `noteindex` gains `Embedding float_vector knn_type='hnsw' knn_dims='1024' hnsw_similarity='cosine'` (`docker/create_table.sql`).
- **Read path** `GetSemanticNoteIdsAsync` runs a KNN query whose owner (`UserId`) + delete-state (`DeletedAt`) filters are the **same** clauses as the keyword path (shared `_BuildOwnerFilterClauses`). `NoteService.SearchUserNotes` merges keyword-hits-first, dedups semantic candidates, and pages over the merged virtual list.
- **Backfill** resumable, batched `NoteVectorBackfillService`, triggered off-peak via `POST /api/admin/vector-backfill/run` (Admin policy); cursor-persisted so a stopped run resumes.
- **Docs** CLAUDE.md search/sync section updated; stale `ManticoreSearch: ⏳ Not yet migrated` line corrected.

## Design decisions / deviations (please gate)
- **Single writer instead of a separate vector sync queue** (the issue suggested mirroring a new enqueuer/handler + service-name constant). Manticore's documented semantics: `UPDATE`/`json/update` **cannot** modify a full-text field *or* a `float_vector` — both require `REPLACE`, which rewrites the whole doc. Two independent writers on one doc are therefore inherently clobber-prone (last-writer-wins drops a field) unless using partial-REPLACE, which needs Manticore Buddy + all-stored fields — an infra dependency I can't verify here. A single writer that rewrites content+vector together is clobber-free on any Manticore ≥6.2 and satisfies the reviewer's plan-gate note #2 ("ensure a replace can't clobber a fresher vector"). Trade-off: a new note becomes keyword-searchable only after its (background) embedding completes; bounded by `EmbeddingTimeoutSeconds`.
- **Manticore-native KNN** used (no fallback vector store), per the issue's primary approach. KNN filter goes in a **sibling top-level `query`** block (verified against the Manticore manual; the vector goes in `knn.query`, distance returned as `_knn_dist`).
- **Deep-paging preserved** (reviewer note #1): keyword hits are paged directly from Manticore (never capped); `KeywordMergeCap` bounds only the set used to dedup the small semantic tail. `_KeywordOnlySearch` now also re-orders to Manticore's ranking (the SQL `IN` fetch loses order) — a small correctness improvement consistent with the merged path.
- **MVP limitation** (documented): if a semantic candidate is also a keyword hit ranked beyond `KeywordMergeCap` (default 1000, far above realistic per-user hit counts), it may rarely double-appear.

## Secrets / deploy
No new GitHub Actions secret for the self-hosted default (Ollama has no key). Only a non-secret embedding endpoint URL is needed, injected like the Manticore/Redis hosts via `sed` in the deploy workflows (`embedding-endpoint-placeholder`). A hosted-API fallback would be the only thing warranting an API-key secret.

## Tests
318 unit tests pass (`TestCategory!=Integration`). New coverage: embedding (disabled/empty/success/dim-mismatch/error), KNN filter+isolation+max-distance construction, embedding-in-REPLACE, merge dedup/ordering, paging across keyword→semantic tail (later pages non-empty), keyword-only fallback, backfill batching/cursor/stop-on-backend-down/skip-empty.

Live end-to-end (Ollama + Manticore-KNN) can't run in CI; `SemanticSearchIntegrationTests` (`[Explicit]`) validates KNN isolation against a real Manticore using injected vectors. **Staging acceptance to run after deploy:** enable the flag, run the backfill, then confirm (1) a conceptual query returns related notes sharing no keyword, (2) two-user isolation + no soft-deleted leakage + own-private returned, (3) paging across the merged list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
